### PR TITLE
20240315 refresh rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,45 @@
 # Rule-901
-Amount of transactions debtor made
+Number of outgoing transactions - debtor
 
 # Sample configuration
 ```json
 {
-    "id": "901@1.0.0",
-    "cfg": "1.0.0",
-    "desc": "Amount of transactions debtor made",
-    "config": {
-      "exitConditions": [
-        {
-          "subRuleRef": ".x00",
-          "outcome": false,
-          "reason": "Unsuccessful transaction"
-        }
-      ],
-      "timeframes": [
-        {
-          "threshold": 86400000
-        }
-      ],
-      "bands": [
-        {
-          "subRuleRef": ".01",
-          "upperLimit": 2,
-          "outcome": true,
-          "reason": "Debtor made less than two transactions"
-        },
-        {
-          "subRuleRef": ".02",
-          "lowerLimit": 2,
-          "upperLimit": 3,
-          "outcome": true,
-          "reason": "Debtor made three transactions"
-        },
-        {
-          "subRuleRef": ".03",
-          "lowerLimit": 3,
-          "outcome": false,
-          "reason": "Debtor made four or more transactions"
-        }
-      ]
-    }
+  "_key": "901@1.0.0@1.0.0",
+  "id": "901@1.0.0",
+  "cfg": "1.0.0",
+  "desc": "Number of outgoing transactions - debtor",
+  "config": {
+    "parameters": {
+      "maxQueryRange": 86400000
+    },
+    "exitConditions": [
+      {
+        "subRuleRef": ".x00",
+        "outcome": false,
+        "reason": "Incoming transaction is unsuccessful"
+      },
+    ],
+    "bands": [
+      {
+        "subRuleRef": ".01",
+        "upperLimit": 2,
+        "outcome": true,
+        "reason": "The debtor has performed one transaction to date"
+      },
+      {
+        "subRuleRef": ".02",
+        "lowerLimit": 2,
+        "upperLimit": 4,
+        "outcome": true,
+        "reason": "The debtor has performed two or three transactions to date"
+      },
+      {
+        "subRuleRef": ".03",
+        "lowerLimit": 4,
+        "outcome": true,
+        "reason": "The debtor has performed 4 or more transactions to date"
+      }
+    ]
   }
+}
 ```

--- a/__tests__/__mocks__/arango.js
+++ b/__tests__/__mocks__/arango.js
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+const arangojs = require('arangojs');
+
+class MockDatabase {
+  constructor(config) {
+    return {
+      exists() {
+        return true;
+      },
+      isArangoDatabase: true,
+      close() { },
+    };
+  }
+}
+
+module.exports = { ...arangojs, Database: MockDatabase };

--- a/__tests__/__mocks__/ioredis.js
+++ b/__tests__/__mocks__/ioredis.js
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Dependency hoisting so third party library uses mock
+module.exports = require('ioredis-mock');

--- a/__tests__/rule-901.test.ts
+++ b/__tests__/rule-901.test.ts
@@ -1,7 +1,0 @@
-import { assert } from "console";
-
-describe('Logic Service', () => {
-    it('should respond with rule result of true for happy path', async () => {
-        expect(true).toEqual(true);
-    });
-});

--- a/__tests__/unit/rule.test.ts
+++ b/__tests__/unit/rule.test.ts
@@ -1,0 +1,533 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { handleTransaction } from '../../src';
+import {
+  type DatabaseManagerInstance,
+  LoggerService,
+  CreateDatabaseManager,
+} from '@frmscoe/frms-coe-lib';
+import {
+  type Band,
+  type DataCache,
+  type RuleConfig,
+  type RuleRequest,
+  type RuleResult,
+} from '@frmscoe/frms-coe-lib/lib/interfaces';
+
+jest.mock('@frmscoe/frms-coe-lib', () => {
+  const original = jest.requireActual('@frmscoe/frms-coe-lib');
+  return {
+    ...original,
+    aql: jest.fn(),
+  };
+});
+
+const getMockRequest = (): RuleRequest => {
+  const quote = {
+    transaction: JSON.parse(
+      `{"TxTp":"pacs.002.001.12","FIToFIPmtSts":{"GrpHdr":{"MsgId":"6b444365119746c5be7dfb5516ba67c4","CreDtTm":"${new Date(
+        'Mon Dec 03 2021 09:24:48 GMT+0000',
+      ).toISOString()}"},"TxInfAndSts":{"OrgnlInstrId":"5ab4fc7355de4ef8a75b78b00a681ed2","OrgnlEndToEndId":"2c516801007642dfb892944dde1cf845","TxSts":"ACCC","ChrgsInf":[{"Amt":{"Amt":307.14,"Ccy":"USD"},"Agt":{"FinInstnId":{"ClrSysMmbId":{"MmbId":"dfsp001"}}}},{"Amt":{"Amt":153.57,"Ccy":"USD"},"Agt":{"FinInstnId":{"ClrSysMmbId":{"MmbId":"dfsp001"}}}},{"Amt":{"Amt":30.71,"Ccy":"USD"},"Agt":{"FinInstnId":{"ClrSysMmbId":{"MmbId":"dfsp002"}}}}],"AccptncDtTm":"2021-12-03T15:36:16.000Z","InstgAgt":{"FinInstnId":{"ClrSysMmbId":{"MmbId":"dfsp001"}}},"InstdAgt":{"FinInstnId":{"ClrSysMmbId":{"MmbId":"dfsp002"}}}}}}`,
+    ),
+
+    networkMap: JSON.parse(
+      '{"_key":"26345403","_id":"networkConfiguration/26345403","_rev":"_cxc-1vO---","messages":[{"id":"001@1.0","host":"http://openfaas:8080","cfg":"1.0.0","txTp":"pain.001.001.11","channels":[{"id":"001@1.0","host":"http://openfaas:8080","cfg":"1.0.0","typologies":[{"id":"028@1.0","host":"https://frmfaas.sybrin.com/function/off-typology-processor","cfg":"028@1.0","rules":[{"id":"004@1.0.0","host":"http://openfaas:8080","cfg":"1.0.0"},{"id":"028@1.0","host":"http://openfaas:8080","cfg":"1.0.0"}]},{"id":"029@1.0","host":"https://frmfaas.sybrin.com/function/off-typology-processor","cfg":"029@1.0","rules":[{"id":"003@1.0","host":"http://openfaas:8080","cfg":"1.0"},{"id":"005@1.0","host":"http://openfaas:8080","cfg":"1.0"}]}]},{"id":"002@1.0","host":"http://openfaas:8080","cfg":"1.0","typologies":[{"id":"030@1.0","host":"https://frmfaas.sybrin.com/function/off-typology-processor","cfg":"030@1.0","rules":[{"id":"003@1.0","host":"http://openfaas:8080","cfg":"1.0"},{"id":"006@1.0","host":"http://openfaas:8080","cfg":"1.0"}]},{"id":"031@1.0","host":"https://frmfaas.sybrin.com/function/off-typology-processor","cfg":"031@1.0","rules":[{"id":"003@1.0","host":"http://openfaas:8080","cfg":"1.0"},{"id":"007@1.0","host":"http://openfaas:8080","cfg":"1.0"}]}]}]}]}',
+    ),
+    DataCache: {
+      dbtrId: 'dbtr_516c7065d75b4fcea6fffb52a9539357',
+      cdtrId: 'cdtr_b086a1e193794192b32c8af8550d721d',
+      dbtrAcctId: 'dbtrAcct_1fd08e408c184dd28cbaeef03bff1af5',
+      cdtrAcctId: 'cdtrAcct_d531e1ba4ed84a248fe26617e79fcb64',
+    },
+  };
+  return quote as RuleRequest;
+};
+
+const databaseManagerConfig = {
+  pseudonyms: {
+    certPath: '',
+    databaseName: '',
+    user: '',
+    password: '',
+    url: '',
+  },
+};
+let databaseManager: DatabaseManagerInstance<typeof databaseManagerConfig>;
+let ruleRes: RuleResult;
+const loggerService: LoggerService = new LoggerService();
+
+const ruleConfig: RuleConfig = {
+  id: '901@1.0.0',
+  cfg: '1.0.0',
+  desc: 'Number of outgoing transactions - debtor',
+  config: {
+    parameters: {
+      maxQueryRange: 86400000,
+    },
+    exitConditions: [
+      {
+        "subRuleRef": ".x00",
+        "outcome": false,
+        "reason": "Incoming transaction is unsuccessful"
+      }
+    ],
+    bands: [
+      {
+        subRuleRef: '.01',
+        upperLimit: 2,
+        outcome: false,
+        reason: 'The debtor has performed one transaction to date',
+      },
+      {
+        subRuleRef: '.02',
+        lowerLimit: 2,
+        upperLimit: 4,
+        outcome: true,
+        reason: 'The debtor has performed two or three transactions to date',
+      },
+      {
+        subRuleRef: '.03',
+        lowerLimit: 4,
+        outcome: true,
+        reason: 'The debtor has performed 4 or more transactions to date',
+      },
+    ],
+  },
+};
+
+beforeAll(async () => {
+  databaseManager = await CreateDatabaseManager(databaseManagerConfig);
+  ruleRes = {
+    id: '901@1.0.0',
+    cfg: '1.0.0',
+    result: false,
+    subRuleRef: '.00',
+    reason: '',
+  };
+});
+
+afterAll(() => {
+  databaseManager.quit();
+});
+
+const determineOutcome = (
+  value: number,
+  ruleConfig: RuleConfig,
+  ruleResult: RuleResult,
+): RuleResult => {
+  if (value != null) {
+    if (ruleConfig.config.bands)
+      for (const band of ruleConfig.config.bands) {
+        if (
+          (!band.lowerLimit || value >= band.lowerLimit) &&
+          (!band.upperLimit || value < band.upperLimit)
+        ) {
+          ruleResult.subRuleRef = band.subRuleRef;
+          ruleResult.result = band.outcome;
+          ruleResult.reason = band.reason;
+          break;
+        }
+      }
+  } else
+    throw new Error(
+      'Value provided undefined, so cannot determine rule outcome',
+    );
+  return ruleResult;
+};
+let req: RuleRequest;
+beforeEach(() => {
+  req = getMockRequest();
+});
+
+describe('Happy path', () => {
+  test('Should respond with .01: The debtor has performed one transaction to date', async () => {
+    const mockQueryFn = jest.fn();
+    const mockBatchesAllFn = jest.fn().mockResolvedValue([[1]]);
+    databaseManager._pseudonymsDb.query = mockQueryFn.mockResolvedValue({
+      batches: {
+        all: mockBatchesAllFn,
+      },
+    });
+    jest.spyOn(databaseManager._pseudonymsDb, 'query');
+
+    const res = await handleTransaction(
+      req,
+      determineOutcome,
+      ruleRes,
+      loggerService,
+      ruleConfig,
+      databaseManager,
+    );
+
+    expect(res).toEqual(
+      JSON.parse(
+        '{"id":"901@1.0.0", "cfg":"1.0.0","result":false,"subRuleRef":".01","reason":"The debtor has performed one transaction to date"}',
+      ),
+    );
+  });
+
+  test('Should respond with .02: The debtor has performed two or three transactions to date', async () => {
+    const mockQueryFn = jest.fn();
+
+    const mockBatchesAllFn = jest.fn().mockResolvedValue([[2]]);
+    databaseManager._pseudonymsDb.query = mockQueryFn.mockResolvedValue({
+      batches: {
+        all: mockBatchesAllFn,
+      },
+    });
+    jest.spyOn(databaseManager._pseudonymsDb, 'query');
+
+    const res = await handleTransaction(
+      req,
+      determineOutcome,
+      ruleRes,
+      loggerService,
+      ruleConfig,
+      databaseManager,
+    );
+
+    expect(res).toEqual(
+      JSON.parse(
+        '{"id":"901@1.0.0", "cfg":"1.0.0","result":true,"subRuleRef":".02","reason":"The debtor has performed two or three transactions to date"}',
+      ),
+    );
+  });
+
+  test('Should respond with .02: The debtor has performed two or three transactions to date', async () => {
+    const mockQueryFn = jest.fn();
+
+    const mockBatchesAllFn = jest.fn().mockResolvedValue([[3]]);
+    databaseManager._pseudonymsDb.query = mockQueryFn.mockResolvedValue({
+      batches: {
+        all: mockBatchesAllFn,
+      },
+    });
+    jest.spyOn(databaseManager._pseudonymsDb, 'query');
+
+    const res = await handleTransaction(
+      req,
+      determineOutcome,
+      ruleRes,
+      loggerService,
+      ruleConfig,
+      databaseManager,
+    );
+
+    expect(res).toEqual(
+      JSON.parse(
+        '{"id":"901@1.0.0", "cfg":"1.0.0","result":true,"subRuleRef":".02","reason":"The debtor has performed two or three transactions to date"}',
+      ),
+    );
+  });
+
+  test('Should respond with .03: The debtor has performed 4 or more transactions to date', async () => {
+    const mockQueryFn = jest.fn();
+
+    const mockBatchesAllFn = jest.fn().mockResolvedValue([[4]]);
+    databaseManager._pseudonymsDb.query = mockQueryFn.mockResolvedValue({
+      batches: {
+        all: mockBatchesAllFn,
+      },
+    });
+    jest.spyOn(databaseManager._pseudonymsDb, 'query');
+
+    const res = await handleTransaction(
+      req,
+      determineOutcome,
+      ruleRes,
+      loggerService,
+      ruleConfig,
+      databaseManager,
+    );
+
+    expect(res).toEqual(
+      JSON.parse(
+        '{"id":"901@1.0.0", "cfg":"1.0.0","result":true,"subRuleRef":".03","reason":"The debtor has performed 4 or more transactions to date"}',
+      ),
+    );
+  });
+
+
+});
+
+describe('Exit conditions', () => {
+
+});
+
+describe('Error conditions', () => {
+
+  test('Unsuccessful transaction and no exit condition', async () => {
+    const mockQueryFn = jest.fn();
+    const mockBatchesAllFn = jest
+      .fn()
+      .mockResolvedValue([[{ currentAmount: 14, highestAmount: 15 }]]);
+    databaseManager._pseudonymsDb.query = mockQueryFn.mockResolvedValue({
+      batches: {
+        all: mockBatchesAllFn,
+      },
+    });
+    jest.spyOn(databaseManager._pseudonymsDb, 'query');
+    const objClone = (req: Object) => JSON.parse(JSON.stringify(req));
+    const newReq: RuleRequest = objClone(req);
+    newReq.transaction.FIToFIPmtSts.TxInfAndSts.TxSts = 'something else';
+    const newConfig: RuleConfig = objClone(ruleConfig);
+    newConfig.config.exitConditions![0].subRuleRef = 'something';
+    try {
+      await handleTransaction(
+        newReq,
+        determineOutcome,
+        ruleRes,
+        loggerService,
+        newConfig,
+        databaseManager,
+      );
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        'Unsuccessful transaction and no exit condition in config',
+      );
+    }
+  });
+
+  test('No transactions', async () => {
+    const mockQueryFn = jest.fn();
+
+    const mockBatchesAllFn = jest.fn().mockResolvedValue([[0]]);
+    databaseManager._pseudonymsDb.query = mockQueryFn.mockResolvedValue({
+      batches: {
+        all: mockBatchesAllFn,
+      },
+    });
+    jest.spyOn(databaseManager._pseudonymsDb, 'query');
+
+    try {
+      await handleTransaction(
+        req,
+        determineOutcome,
+        ruleRes,
+        loggerService,
+        ruleConfig,
+        databaseManager,
+      );
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        'Data error: irretrievable transaction history',
+      );
+    }
+  });
+
+  test('Not a number', async () => {
+    const mockQueryFn = jest.fn();
+
+    const mockBatchesAllFn = jest.fn().mockResolvedValue([['abc']]);
+    databaseManager._pseudonymsDb.query = mockQueryFn.mockResolvedValue({
+      batches: {
+        all: mockBatchesAllFn,
+      },
+    });
+    jest.spyOn(databaseManager._pseudonymsDb, 'query');
+
+    try {
+      await handleTransaction(
+        req,
+        determineOutcome,
+        ruleRes,
+        loggerService,
+        ruleConfig,
+        databaseManager,
+      );
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        'Data error: query result type mismatch - expected a number',
+      );
+    }
+  });
+
+  test('Invalid query result', async () => {
+    // Mocking the request of getting oldes transation timestamp
+    const mockQueryFn = jest.fn();
+    const mockBatchesAllFn = jest.fn().mockResolvedValue([[undefined]]);
+    databaseManager._pseudonymsDb.query = mockQueryFn.mockResolvedValue({
+      batches: {
+        all: mockBatchesAllFn,
+      },
+    });
+    jest.spyOn(databaseManager._pseudonymsDb, 'query');
+
+    try {
+      await handleTransaction(
+        req,
+        determineOutcome,
+        ruleRes,
+        loggerService,
+        ruleConfig,
+        databaseManager,
+      );
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        'Data error: irretrievable transaction history',
+      );
+    }
+  });
+
+  test('No data cache', async () => {
+    // Mocking the request of getting oldes transation timestamp
+    const mockQueryFn = jest.fn();
+    const mockBatchesAllFn = jest.fn().mockResolvedValue([[undefined]]);
+    databaseManager._pseudonymsDb.query = mockQueryFn.mockResolvedValue({
+      batches: {
+        all: mockBatchesAllFn,
+      },
+    });
+    jest.spyOn(databaseManager._pseudonymsDb, 'query');
+
+    try {
+      await handleTransaction(
+        { ...req, DataCache: { ...req.DataCache, dbtrAcctId: undefined } },
+        determineOutcome,
+        ruleRes,
+        loggerService,
+        ruleConfig,
+        databaseManager,
+      );
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        'Data Cache does not have required dbtrAcctId',
+      );
+    }
+
+    try {
+      await handleTransaction(
+        { ...req, DataCache: undefined as unknown as DataCache },
+        determineOutcome,
+        ruleRes,
+        loggerService,
+        ruleConfig,
+        databaseManager,
+      );
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        'Data Cache does not have required dbtrAcctId',
+      );
+    }
+  });
+
+  test('Invalid config', async () => {
+    const mockQueryFn = jest.fn();
+
+    const mockBatchesAllFn = jest.fn().mockResolvedValue([['abc']]);
+    databaseManager._pseudonymsDb.query = mockQueryFn.mockResolvedValue({
+      batches: {
+        all: mockBatchesAllFn,
+      },
+    });
+    jest.spyOn(databaseManager._pseudonymsDb, 'query');
+
+    try {
+      await handleTransaction(
+        req,
+        determineOutcome,
+        ruleRes,
+        loggerService,
+        {
+          ...ruleConfig,
+          config: { ...ruleConfig.config, parameters: undefined },
+        },
+        databaseManager,
+      );
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        'Invalid config provided - parameters not provided',
+      );
+    }
+    
+    try {
+      await handleTransaction(
+        req,
+        determineOutcome,
+        ruleRes,
+        loggerService,
+        {
+          ...ruleConfig,
+          config: { ...ruleConfig.config, parameters: { '1': 2 } },
+        },
+        databaseManager,
+      );
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        'Invalid config provided - maxQueryRange parameter not provided',
+      );
+    }
+
+    try {
+      await handleTransaction(
+        req,
+        determineOutcome,
+        ruleRes,
+        loggerService,
+        {
+          ...ruleConfig,
+          config: { ...ruleConfig.config, exitConditions: undefined },
+        },
+        databaseManager,
+      );
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        'Invalid config provided - exitConditions not provided',
+      );
+    }
+
+    try {
+      await handleTransaction(
+        req,
+        determineOutcome,
+        ruleRes,
+        loggerService,
+        {
+          ...ruleConfig,
+          config: { ...ruleConfig.config, bands: [] },
+        },
+        databaseManager,
+      );
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        'Invalid config provided - bands not provided or empty',
+      );
+    }
+
+    try {
+      await handleTransaction(
+        req,
+        determineOutcome,
+        ruleRes,
+        loggerService,
+        {
+          ...ruleConfig,
+          config: {
+            ...ruleConfig.config,
+            bands: undefined as unknown as Band[],
+          },
+        },
+        databaseManager,
+      );
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        'Invalid config provided - bands not provided or empty',
+      );
+    }
+
+    try {
+      await handleTransaction(
+        req,
+        determineOutcome,
+        ruleRes,
+        loggerService,
+        undefined as unknown as RuleConfig,
+        databaseManager,
+      );
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        'Invalid config provided - bands not provided or empty',
+      );
+    }
+  });
+});

--- a/__tests__/unit/rule.test.ts
+++ b/__tests__/unit/rule.test.ts
@@ -44,7 +44,7 @@ const getMockRequest = (): RuleRequest => {
         amt: 1234.56,
         ccy: 'XTS'
       },
-      creDtTm: `${new Date( Date.now() - 60 * 1000).toISOString()}`
+      creDtTm: `${new Date(Date.now() - 60 * 1000).toISOString()}`
     },
   };
   return quote as RuleRequest;
@@ -260,6 +260,28 @@ describe('Happy path', () => {
 
 describe('Exit conditions', () => {
 
+  test('Should respond with .x00: Incoming transaction is unsuccessful', async () => {
+    const mockQueryFn = jest.fn();
+
+    const objClone = (req: Object) => JSON.parse(JSON.stringify(req));
+    const newReq: RuleRequest = objClone(req);
+    newReq.transaction.FIToFIPmtSts.TxInfAndSts.TxSts = 'something else';
+    const res = await handleTransaction(
+      newReq,
+      determineOutcome,
+      ruleRes,
+      loggerService,
+      ruleConfig,
+      databaseManager,
+    );
+
+    expect(res).toEqual(
+      JSON.parse(
+        '{"id":"901@1.0.0", "cfg":"1.0.0","result":false,"subRuleRef":".x00","reason":"Incoming transaction is unsuccessful"}',
+      ),
+    );
+  });
+
 });
 
 describe('Error conditions', () => {
@@ -447,7 +469,7 @@ describe('Error conditions', () => {
         'Invalid config provided - parameters not provided',
       );
     }
-    
+
     try {
       await handleTransaction(
         req,

--- a/__tests__/unit/rule.test.ts
+++ b/__tests__/unit/rule.test.ts
@@ -33,11 +33,18 @@ const getMockRequest = (): RuleRequest => {
     networkMap: JSON.parse(
       '{"_key":"26345403","_id":"networkConfiguration/26345403","_rev":"_cxc-1vO---","messages":[{"id":"004@1.0.0","cfg":"1.0.0","txTp":"pacs.002.001.12","channels":[{"id":"001@1.0.0","cfg":"1.0.0","typologies":[{"id":"901@1.0.0","cfg":"028@1.0","rules":[{"id":"004@1.0.0","cfg":"1.0.0"},{"id":"028@1.0","cfg":"1.0.0"}]},{"id":"029@1.0","cfg":"029@1.0","rules":[{"id":"003@1.0","cfg":"1.0"},{"id":"005@1.0","cfg":"1.0"}]}]},{"id":"002@1.0","cfg":"1.0","typologies":[{"id":"030@1.0","cfg":"030@1.0","rules":[{"id":"003@1.0","cfg":"1.0"},{"id":"006@1.0","cfg":"1.0"}]},{"id":"031@1.0","cfg":"031@1.0","rules":[{"id":"003@1.0","cfg":"1.0"},{"id":"007@1.0","cfg":"1.0"}]}]}]}]}',
     ),
+
     DataCache: {
       dbtrId: 'dbtr_516c7065d75b4fcea6fffb52a9539357',
       cdtrId: 'cdtr_b086a1e193794192b32c8af8550d721d',
       dbtrAcctId: 'dbtrAcct_1fd08e408c184dd28cbaeef03bff1af5',
       cdtrAcctId: 'cdtrAcct_d531e1ba4ed84a248fe26617e79fcb64',
+      evtId: 'eventId',
+      amt: {
+        amt: 1234.56,
+        ccy: 'XTS'
+      },
+      creDtTm: `${new Date( Date.now() - 60 * 1000).toISOString()}`
     },
   };
   return quote as RuleRequest;

--- a/__tests__/unit/rule.test.ts
+++ b/__tests__/unit/rule.test.ts
@@ -31,7 +31,7 @@ const getMockRequest = (): RuleRequest => {
     ),
 
     networkMap: JSON.parse(
-      '{"_key":"26345403","_id":"networkConfiguration/26345403","_rev":"_cxc-1vO---","messages":[{"id":"001@1.0","host":"http://openfaas:8080","cfg":"1.0.0","txTp":"pain.001.001.11","channels":[{"id":"001@1.0","host":"http://openfaas:8080","cfg":"1.0.0","typologies":[{"id":"028@1.0","host":"https://frmfaas.sybrin.com/function/off-typology-processor","cfg":"028@1.0","rules":[{"id":"004@1.0.0","host":"http://openfaas:8080","cfg":"1.0.0"},{"id":"028@1.0","host":"http://openfaas:8080","cfg":"1.0.0"}]},{"id":"029@1.0","host":"https://frmfaas.sybrin.com/function/off-typology-processor","cfg":"029@1.0","rules":[{"id":"003@1.0","host":"http://openfaas:8080","cfg":"1.0"},{"id":"005@1.0","host":"http://openfaas:8080","cfg":"1.0"}]}]},{"id":"002@1.0","host":"http://openfaas:8080","cfg":"1.0","typologies":[{"id":"030@1.0","host":"https://frmfaas.sybrin.com/function/off-typology-processor","cfg":"030@1.0","rules":[{"id":"003@1.0","host":"http://openfaas:8080","cfg":"1.0"},{"id":"006@1.0","host":"http://openfaas:8080","cfg":"1.0"}]},{"id":"031@1.0","host":"https://frmfaas.sybrin.com/function/off-typology-processor","cfg":"031@1.0","rules":[{"id":"003@1.0","host":"http://openfaas:8080","cfg":"1.0"},{"id":"007@1.0","host":"http://openfaas:8080","cfg":"1.0"}]}]}]}]}',
+      '{"_key":"26345403","_id":"networkConfiguration/26345403","_rev":"_cxc-1vO---","messages":[{"id":"004@1.0.0","cfg":"1.0.0","txTp":"pacs.002.001.12","channels":[{"id":"001@1.0.0","cfg":"1.0.0","typologies":[{"id":"901@1.0.0","cfg":"028@1.0","rules":[{"id":"004@1.0.0","cfg":"1.0.0"},{"id":"028@1.0","cfg":"1.0.0"}]},{"id":"029@1.0","cfg":"029@1.0","rules":[{"id":"003@1.0","cfg":"1.0"},{"id":"005@1.0","cfg":"1.0"}]}]},{"id":"002@1.0","cfg":"1.0","typologies":[{"id":"030@1.0","cfg":"030@1.0","rules":[{"id":"003@1.0","cfg":"1.0"},{"id":"006@1.0","cfg":"1.0"}]},{"id":"031@1.0","cfg":"031@1.0","rules":[{"id":"003@1.0","cfg":"1.0"},{"id":"007@1.0","cfg":"1.0"}]}]}]}]}',
     ),
     DataCache: {
       dbtrId: 'dbtr_516c7065d75b4fcea6fffb52a9539357',
@@ -52,6 +52,7 @@ const databaseManagerConfig = {
     url: '',
   },
 };
+
 let databaseManager: DatabaseManagerInstance<typeof databaseManagerConfig>;
 let ruleRes: RuleResult;
 const loggerService: LoggerService = new LoggerService();
@@ -90,9 +91,9 @@ const ruleConfig: RuleConfig = {
         lowerLimit: 4,
         outcome: true,
         reason: 'The debtor has performed 4 or more transactions to date',
-      },
-    ],
-  },
+      }
+    ]
+  }
 };
 
 beforeAll(async () => {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -106,7 +106,10 @@ const config: Config.InitialOptions = {
   // ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper: {
+    '^ioredis$': '<rootDir>/__tests__/__mocks__/ioredis.js',
+    '^arangojs$': '<rootDir>/__tests__/__mocks__/arango.js',
+  },
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+
 import { handleTransaction } from './rule-901'
 export { handleTransaction }

--- a/src/rule-901.ts
+++ b/src/rule-901.ts
@@ -27,8 +27,8 @@ export async function handleTransaction(
   databaseManager: DatabaseManagerInstance<ManagerConfig>,
 ): Promise<RuleResult> {
 
-  let context = (ruleConfig && typeof ruleConfig.id !== undefined) ? `Rule-${ruleConfig.id} handleTransaction()` : `Rule-<unresolved> handleTransaction()`
-  let msgId = req.transaction.FIToFIPmtSts.GrpHdr.MsgId
+  const context = (ruleConfig && typeof ruleConfig.id !== undefined) ? `Rule-${ruleConfig.id} handleTransaction()` : `Rule-<unresolved> handleTransaction()`
+  const msgId = req.transaction.FIToFIPmtSts.GrpHdr.MsgId
 
   loggerService.log(
     'Start - handle transaction',

--- a/src/rule-901.ts
+++ b/src/rule-901.ts
@@ -27,7 +27,7 @@ export async function handleTransaction(
   databaseManager: DatabaseManagerInstance<ManagerConfig>,
 ): Promise<RuleResult> {
 
-  let context = `Rule-${ruleConfig.id} handleTransaction()`
+  let context = (ruleConfig && typeof ruleConfig.id !== undefined) ? `Rule-${ruleConfig.id} handleTransaction()` : `Rule-<unresolved> handleTransaction()`
   let msgId = req.transaction.FIToFIPmtSts.GrpHdr.MsgId
 
   loggerService.log(

--- a/src/rule-901.ts
+++ b/src/rule-901.ts
@@ -27,7 +27,7 @@ export async function handleTransaction(
   databaseManager: DatabaseManagerInstance<ManagerConfig>,
 ): Promise<RuleResult> {
 
-  const context = (ruleConfig && typeof ruleConfig.id !== undefined) ? `Rule-${ruleConfig.id} handleTransaction()` : `Rule-<unresolved> handleTransaction()`
+  const context = `Rule-${ruleConfig?.id ? ruleConfig.id : '<unresolved>'} handleTransaction()`;
   const msgId = req.transaction.FIToFIPmtSts.GrpHdr.MsgId
 
   loggerService.log(


### PR DESCRIPTION
Updated the template rule-901 to reflect the latest functionality:

- [x] Added Jest unit testing for rule-901
- [x] Added interior logging via the LoggerService for rule-901
- [x] Added handling for exit conditions (.x00 - unsuccessful transaction)
- [x] Fixed/Updated handling for a `maxQueryRange` parameter inside a `parameters` object
- [x] Added comments to separate the 4 rule processor steps (Exit conditions / Query prep / Query execution / Query Post-Processing)

## Jest test result:
![image](https://github.com/frmscoe/rule-901/assets/123470803/87860804-2145-4876-862c-722ad4c02987)

## Interior Rule Logging:
![image](https://github.com/frmscoe/rule-901/assets/123470803/bdd9ed13-3e9e-462b-8139-284774a63fc9)


