### PR TITLE
chore: bump lib ver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@frmscoe/rule-901",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@frmscoe/rule-901",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@frmscoe/frms-coe-lib": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frmscoe/rule-901",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Rule 091 is to calculate the number of transactions the debtor has made over a period",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
CI on main fails because pkg version was not pumped.