### PR TITLE
build: fix workflows for publishing rule 901 on updating dev and main

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build Rule Packages
         run: |
           echo "Building rule packages..."
-          cd rule-executer-901 && npm install
+          cd rule-executer && npm install
           echo "Rule packages built."
 
       # Step 6: Build and Push Docker Image

--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -27,11 +27,12 @@ jobs:
       # Step 2: Clone Rule Executer Repo and delete package-lock.json file
       - name: Clone Rule Executer Repo
         run: |
-          echo "Cloning Rule Executer repo and removing package-lock.json file..."
+          echo "Cloning Rule Executer repo"
           git clone https://github.com/tazama-lf/rule-executer -b dev
           cd rule-executer 
           sed -i 's/${GH_TOKEN}/${{ secrets.GH_TOKEN_LIB }}/' .npmrc 
           cat .npmrc
+          cd ..
           echo "Clone completed."
 
       # Step 5: Build Rule Packages
@@ -39,6 +40,7 @@ jobs:
         run: |
           echo "Building rule packages..."
           cd rule-executer && npm install
+          cd ..
           echo "Rule packages built."
 
       # Step 6: Build and Push Docker Image
@@ -48,6 +50,8 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           echo "Packaging rule processors into Docker image..."
+          cd ..
+          cat Dockerfile
           docker build -t tazamaorg/rule-901:rc .
           echo "Logging into DockerHub..."
           echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -27,7 +27,7 @@ jobs:
       # Step 2: Clone Rule Executer Repo and delete package-lock.json file
       - name: Clone Rule Executer Repo
         run: |
-          echo "Cloning Rule Executer repo and removing package-lock.json file..."
+          echo "Cloning Rule Executer repo"
           git clone https://github.com/tazama-lf/rule-executer -b dev
           cd rule-executer 
           sed -i 's/${GH_TOKEN}/${{ secrets.GH_TOKEN_LIB }}/' .npmrc 
@@ -49,6 +49,8 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
+          cd ..
+          cat Dockerfile
           echo "Packaging rule processors into Docker image..."
           docker build -t tazamaorg/rule-901:2.2.0 .
           echo "Logging into DockerHub..."


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Fix workflows for publishing rule 901 on updating dev and main

## Why are we doing this?
Previous failing builds

## How was it tested?
- [x] Locally
- [ ] Development Environment
- [ ] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
