### PR TITLE
build: fix workflows for publishing rule 901 on updating dev and main

### DIFF
--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -50,8 +50,7 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           echo "Packaging rule processors into Docker image..."
-          cd ..
-          cat Dockerfile
+          cd rule-executer && cat Dockerfile
           docker build -t tazamaorg/rule-901:rc .
           echo "Logging into DockerHub..."
           echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -49,9 +49,8 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
-          cd ..
-          cat Dockerfile
           echo "Packaging rule processors into Docker image..."
+          cd rule-executer && cat Dockerfile
           docker build -t tazamaorg/rule-901:2.2.0 .
           echo "Logging into DockerHub..."
           echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Fx workflows for publishing rule 901 on updating dev and main

## Why are we doing this?
Previous failing build found no Dockerfile because of wrong command

## How was it tested?
- [ ] Locally
- [ ] Development Environment
- [x] Not needed, changes very basic
- [ ] Husky successfully run
- [ ] Unit tests passing and Documentation done
