### PR TITLE
build: dependency and version update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "6.0.0-rc.6"
+        "@tazama-lf/frms-coe-lib": "6.0.0-rc.9"
       },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
@@ -1535,7 +1535,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "6.0.0-rc.6",
+      "version": "6.0.0-rc.9",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/6.0.0-rc.9/b159ced4a75bc2d703efcfd5317274787d104093",
+      "integrity": "sha512-ejPG5T9oltmlniac9JB9SG+1ffDMpud2d4+K3TYvxTUgocq1KhKk4KpoDBMzmcwZywu40wMjeDgSEtyVQ5iDwg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/rule-901",
-  "version": "3.0.0-rc.0",
+  "version": "3.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/rule-901",
-      "version": "3.0.0-rc.0",
+      "version": "3.0.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/frms-coe-lib": "6.0.0-rc.9"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/rule-901",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/rule-901",
-      "version": "3.0.0-rc.1",
+      "version": "3.0.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/frms-coe-lib": "6.0.0-rc.9"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     ]
   },
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "6.0.0-rc.6"
+    "@tazama-lf/frms-coe-lib": "6.0.0-rc.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/rule-901",
-  "version": "3.0.0-rc.0",
+  "version": "3.0.0-rc.1",
   "description": "Rule 901 is to calculate the number of transactions the debtor has made over a period",
   "main": "index.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/rule-901",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0-rc.2",
   "description": "Rule 901 is to calculate the number of transactions the debtor has made over a period",
   "main": "index.ts",
   "files": [


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Updated `frms-coe-lib` to 6.0.0-rc.9

## Why are we doing this?
To fix an issue pointed out for the multi-tenancy implementation.
Ref: [Issue_1](https://github.com/tazama-lf/rule-executer/issues/311), [Issues_2](https://github.com/tazama-lf/rule-executer/issues/312)

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done