### PR TITLE
feat: implemented JSON schema for the rule config

### DIFF
--- a/__tests__/unit/rule.test.ts
+++ b/__tests__/unit/rule.test.ts
@@ -3,7 +3,7 @@
 import { type DatabaseManagerInstance, LoggerService, CreateDatabaseManager } from '@tazama-lf/frms-coe-lib';
 import { type Band, type RuleConfig, type RuleRequest, type RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 import { CreateStorageManager } from '@tazama-lf/frms-coe-lib/lib/services/dbManager';
-import { handleTransaction } from '../../src';
+import { handleTransaction, getRuleConfigSchema } from '../../src';
 import { RuleExecutorConfig } from '../../src/rule-901';
 
 jest.mock('@tazama-lf/frms-coe-lib', () => {
@@ -104,13 +104,13 @@ const ruleConfig: RuleConfig = {
       {
         subRuleRef: '.02',
         lowerLimit: 2,
-        upperLimit: 4,
-        reason: 'The debtor has performed two or three transactions to date',
+        upperLimit: 3,
+        reason: 'The debtor has performed two transactions to date',
       },
       {
         subRuleRef: '.03',
-        lowerLimit: 4,
-        reason: 'The debtor has performed 4 or more transactions to date',
+        lowerLimit: 3,
+        reason: 'The debtor has performed three or more transactions to date',
       },
     ],
   },
@@ -125,6 +125,7 @@ beforeAll(async () => {
     cfg: '1.0.0',
     tenantId: 'DEFAULT',
     subRuleRef: '.00',
+    indpdntVarbl: 0,
     reason: '',
   };
 });
@@ -134,6 +135,7 @@ afterAll(() => {
 
 const determineOutcome = (value: number, ruleConfig: RuleConfig, ruleResult: RuleResult): RuleResult => {
   if (value != null) {
+    ruleResult.indpdntVarbl = value;
     if (ruleConfig.config.bands)
       for (const band of ruleConfig.config.bands) {
         if ((!band.lowerLimit || value >= band.lowerLimit) && (!band.upperLimit || value < band.upperLimit)) {
@@ -146,9 +148,20 @@ const determineOutcome = (value: number, ruleConfig: RuleConfig, ruleResult: Rul
   } else throw new Error('Value provided undefined, so cannot determine rule outcome');
   return ruleResult;
 };
+
 let req: RuleRequest;
+
 beforeEach(() => {
   req = getMockRequest();
+
+  ruleRes = {
+    id: 'DEFAULT-901@1.0.0',
+    cfg: '1.0.0',
+    tenantId: 'DEFAULT',
+    subRuleRef: '.00',
+    indpdntVarbl: 0,
+    reason: '',
+  };
 });
 
 describe('Happy path', () => {
@@ -160,11 +173,11 @@ describe('Happy path', () => {
     const res = await handleTransaction(req, determineOutcome, ruleRes, loggerService, ruleConfig, databaseManager);
 
     expect(res).toEqual(
-      JSON.parse('{"id":"DEFAULT-901@1.0.0", "cfg":"1.0.0","subRuleRef":".01","reason":"The debtor has performed one transaction to date", "tenantId":"DEFAULT"}'),
+      JSON.parse('{"id":"DEFAULT-901@1.0.0", "cfg":"1.0.0","subRuleRef":".01","indpdntVarbl":1,"reason":"The debtor has performed one transaction to date", "tenantId":"DEFAULT"}'),
     );
   });
 
-  test('Should respond with .02: The debtor has performed two or three transactions to date', async () => {
+  test('Should respond with .02: The debtor has performed two transactions to date', async () => {
     const mockQueryFn = jest.fn();
     databaseManager._eventHistory.query = mockQueryFn.mockResolvedValue({ rows: [{ length: 2 }]});
     jest.spyOn(databaseManager._eventHistory, 'query');
@@ -173,34 +186,20 @@ describe('Happy path', () => {
 
     expect(res).toEqual(
       JSON.parse(
-        '{"id":"DEFAULT-901@1.0.0", "cfg":"1.0.0","subRuleRef":".02","reason":"The debtor has performed two or three transactions to date", "tenantId":"DEFAULT"}',
+        '{"id":"DEFAULT-901@1.0.0", "cfg":"1.0.0","subRuleRef":".02","indpdntVarbl":2,"reason":"The debtor has performed two transactions to date", "tenantId":"DEFAULT"}',
       ),
     );
   });
 
-  test('Should respond with .02: The debtor has performed two or three transactions to date', async () => {
+  test('Should respond with .03: The debtor has performed three or more transactions to date', async () => {
     const mockQueryFn = jest.fn();
-    databaseManager._eventHistory.query = mockQueryFn.mockResolvedValue({ rows: [{ length: 2 }]});
+    databaseManager._eventHistory.query = mockQueryFn.mockResolvedValue({ rows: [{ length: 3 }]});
     jest.spyOn(databaseManager._eventHistory, 'query');
 
     const res = await handleTransaction(req, determineOutcome, ruleRes, loggerService, ruleConfig, databaseManager);
 
     expect(res).toEqual(
-      JSON.parse(
-        '{"id":"DEFAULT-901@1.0.0", "cfg":"1.0.0","subRuleRef":".02","reason":"The debtor has performed two or three transactions to date", "tenantId":"DEFAULT"}',
-      ),
-    );
-  });
-
-  test('Should respond with .03: The debtor has performed 4 or more transactions to date', async () => {
-    const mockQueryFn = jest.fn();
-    databaseManager._eventHistory.query = mockQueryFn.mockResolvedValue({ rows: [{ length: 4 }]});
-    jest.spyOn(databaseManager._eventHistory, 'query');
-
-    const res = await handleTransaction(req, determineOutcome, ruleRes, loggerService, ruleConfig, databaseManager);
-
-    expect(res).toEqual(
-      JSON.parse('{"id":"DEFAULT-901@1.0.0", "cfg":"1.0.0","subRuleRef":".03","reason":"The debtor has performed 4 or more transactions to date", "tenantId":"DEFAULT"}'),
+      JSON.parse('{"id":"DEFAULT-901@1.0.0", "cfg":"1.0.0","subRuleRef":".03","indpdntVarbl":3,"reason":"The debtor has performed three or more transactions to date", "tenantId":"DEFAULT"}'),
     );
   });
 });
@@ -213,7 +212,7 @@ describe('Exit conditions', () => {
     const res = await handleTransaction(newReq, determineOutcome, ruleRes, loggerService, ruleConfig, databaseManager);
 
     expect(res).toEqual(
-      JSON.parse('{"id":"DEFAULT-901@1.0.0", "cfg":"1.0.0","subRuleRef":".x00","reason":"Incoming transaction is unsuccessful", "tenantId":"DEFAULT"}'),
+      JSON.parse('{"id":"DEFAULT-901@1.0.0", "cfg":"1.0.0","subRuleRef":".x00","indpdntVarbl":0,"reason":"Incoming transaction is unsuccessful", "tenantId":"DEFAULT"}'),
     );
   });
 });
@@ -390,5 +389,55 @@ describe('Error conditions', () => {
     } catch (error) {
       expect((error as Error).message).toBe('Invalid ruleConfig provided - bands not provided or empty');
     }
+  });
+});
+
+describe('getRuleConfigSchema', () => {
+  it('should return a valid schema object', () => {
+    const schema = getRuleConfigSchema();
+    
+    expect(schema).toBeDefined();
+    expect(typeof schema).toBe('object');
+    expect(schema).not.toBeNull();
+  });
+
+  it('should return schema with required root properties', () => {
+    const schema = getRuleConfigSchema();
+    
+    expect(schema.type).toBe('object');
+    expect(schema.properties).toBeDefined();
+    expect(schema.required).toContain('id');
+    expect(schema.required).toContain('cfg');
+    expect(schema.required).toContain('config');
+    expect(schema.required).toContain('tenantId');
+  });
+
+  it('should have config properties with correct structure', () => {
+    const schema = getRuleConfigSchema();
+    
+    expect(schema.properties.config).toBeDefined();
+    expect(schema.properties.config.properties).toBeDefined();
+    expect(schema.properties.config.properties.parameters).toBeDefined();
+    expect(schema.properties.config.properties.exitConditions).toBeDefined();
+    expect(schema.properties.config.properties.bands).toBeDefined();
+  });
+
+  it('should enforce specific exitConditions schema', () => {
+    const schema = getRuleConfigSchema();
+    const exitConditions = schema.properties.config.properties.exitConditions;
+    
+    expect(exitConditions.minItems).toBe(1);
+    expect(exitConditions.maxItems).toBe(1);
+    expect(exitConditions.items.properties.subRuleRef.enum).toContain('.x00');
+    expect(exitConditions.items.properties.reason.enum).toContain('Incoming transaction is unsuccessful');
+  });
+
+  it('should enforce minimum bands requirement', () => {
+    const schema = getRuleConfigSchema();
+    const bands = schema.properties.config.properties.bands;
+    
+    expect(bands.minItems).toBe(2);
+    expect(bands.items.required).toContain('subRuleRef');
+    expect(bands.items.required).toContain('reason');
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tazama-lf/rule-901",
-  "version": "3.0.0-rc.6",
+  "version": "3.1.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/rule-901",
-      "version": "3.0.0-rc.6",
+      "version": "3.1.0-rc.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/frms-coe-lib": "6.0.0-postgres.alpha.11"
@@ -63,7 +63,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -758,13 +757,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -797,9 +796,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.0.tgz",
-      "integrity": "sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.1.tgz",
+      "integrity": "sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -871,9 +870,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.37.0.tgz",
-      "integrity": "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==",
+      "version": "9.38.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
+      "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -884,9 +883,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1644,7 +1643,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -1704,6 +1702,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -1828,14 +1832,14 @@
       }
     },
     "node_modules/@stylistic/eslint-plugin": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.4.0.tgz",
-      "integrity": "sha512-UG8hdElzuBDzIbjG1QDwnYH0MQ73YLXDFHgZzB4Zh/YJfnw8XNsloVtytqzx0I2Qky9THSdpTmi8Vjn/pf/Lew==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.5.0.tgz",
+      "integrity": "sha512-IeZF+8H0ns6prg4VrkhgL+yrvDXWDH2cKchrbh80ejG9dQgZWp10epHMbgRuQvgchLII/lfh6Xn3lu6+6L86Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.0",
-        "@typescript-eslint/types": "^8.44.0",
+        "@typescript-eslint/types": "^8.46.1",
         "eslint-visitor-keys": "^4.2.1",
         "espree": "^10.4.0",
         "estraverse": "^5.3.0",
@@ -2046,11 +2050,10 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.7.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.2.tgz",
-      "integrity": "sha512-/NbVmcGTP+lj5oa4yiYxxeBjRivKQ5Ns1eSZeB99ExsEQ6rX5XYU1Zy/gGxY/ilqtD4Etx9mKyrPxZRetiahhA==",
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.1.tgz",
+      "integrity": "sha512-alv65KGRadQVfVcG69MuB4IzdYVpRwMG/mq8KWOaoOdyY617P5ivaDiMCGOFDWD2sAn5Q0mR3mRtUOgm99hL9Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.14.0"
       }
@@ -2142,7 +2145,6 @@
       "integrity": "sha512-6JSSaBZmsKvEkbRUkf7Zj7dru/8ZCrJxAqArcLaVMee5907JdtEbKGsZ7zNiIm/UAkpGUkaSMZEXShnN2D1HZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -2622,7 +2624,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3110,9 +3111,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.16",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.16.tgz",
-      "integrity": "sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==",
+      "version": "2.8.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.18.tgz",
+      "integrity": "sha512-UYmTpOBwgPScZpS4A+YbapwWuBwasxvO/2IOHArSsAhL/+ZdmATBXTex3t+l2hXwLVYK382ibr/nKoY9GKe86w==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3198,7 +3199,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -3335,9 +3335,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001750",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001750.tgz",
-      "integrity": "sha512-cuom0g5sdX6rw00qOoLNSFCJ9/mYIsuSOA+yzpDw8eopiFqcVwQvZHqov0vmEighRxX++cfC0Vg1G+1Iy/mSpQ==",
+      "version": "1.0.30001751",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001751.tgz",
+      "integrity": "sha512-A0QJhug0Ly64Ii3eIqHu5X51ebln3k4yTUkY1j8drqpWHVreg/VLijN48cZ1bYPiqOQuqpkIKnzr/Ul8V+p6Cw==",
       "dev": true,
       "funding": [
         {
@@ -3579,9 +3579,9 @@
       }
     },
     "node_modules/collect-v8-coverage": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
-      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3928,9 +3928,9 @@
       "license": "MIT"
     },
     "node_modules/elastic-apm-node": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-4.14.0.tgz",
-      "integrity": "sha512-SiA34EevGg1P9tCXca1BydVhNX1H++rHW9QXdQSasMr3+3eRtTx5qnGL4SRm5CRy55yFMmajeZJXafqgHTrOYw==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-4.15.0.tgz",
+      "integrity": "sha512-8N176AlRizpX+JcNP3xPPbl9HjiDG6PRTIY0XfY2SSmI7dAvxlYk/TFBcOXeGpoMTYCHZHNPUUL0ryvaMV7EGA==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -3951,7 +3951,7 @@
         "fast-safe-stringify": "^2.0.7",
         "fast-stream-to-buffer": "^1.0.0",
         "http-headers": "^3.0.2",
-        "import-in-the-middle": "1.14.2",
+        "import-in-the-middle": "1.14.4",
         "json-bigint": "^1.0.0",
         "lru-cache": "10.2.0",
         "measured-reporting": "^1.51.1",
@@ -3963,7 +3963,7 @@
         "pino": "^8.15.0",
         "readable-stream": "^3.6.2",
         "relative-microtime": "^2.0.0",
-        "require-in-the-middle": "^7.1.1",
+        "require-in-the-middle": "^8.0.0",
         "semver": "^7.5.4",
         "shallow-clone-shim": "^2.0.0",
         "source-map": "^0.8.0-beta.0",
@@ -4312,26 +4312,24 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.37.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
-      "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
+      "version": "9.38.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
+      "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.4.0",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.1",
         "@eslint/core": "^0.16.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.37.0",
+        "@eslint/js": "9.38.0",
         "@eslint/plugin-kit": "^0.4.0",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
@@ -4987,7 +4985,6 @@
       "integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readline-sync": "^1.4.9",
         "sprintf-js": "^1.1.1",
@@ -5652,9 +5649,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.2.tgz",
-      "integrity": "sha512-5tCuY9BV8ujfOpwtAGgsTx9CGUapcFMEEyByLv1B+v2+6DhAcw+Zr0nhQT7uwaZ7DiourxFEscghOR8e1aPLQw==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.4.tgz",
+      "integrity": "sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==",
       "license": "Apache-2.0",
       "dependencies": {
         "acorn": "^8.14.0",
@@ -5731,7 +5728,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.1.tgz",
       "integrity": "sha512-Qho8TgIamqEPdgiMadJwzRMW3TudIg6vpg4YONokGDudy4eqRIJtDbVX72pfLBcWxvbn3qm/40TyGUObdW4tLQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.4.0",
         "cluster-key-slot": "^1.1.0",
@@ -5867,6 +5863,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -6337,7 +6334,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -7576,9 +7572,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
-      "integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
+      "version": "2.0.25",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.25.tgz",
+      "integrity": "sha512-4auku8B/vw5psvTiiN9j1dAOsXvMoGqJuKJcR+dTdqiXEK20mMTk1UEo3HS16LeGQsVG6+qKTPM9u/qQ2LqATA==",
       "dev": true,
       "license": "MIT"
     },
@@ -7941,6 +7937,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -7965,7 +7962,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -8084,11 +8080,12 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.13.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.13.1.tgz",
-      "integrity": "sha512-Szuj+ViDTjKPQYiKumGmEn3frdl+ZPSdosHyt9SnUevFosOkMY2b7ipxlEctNKPmMD/VibeBI+ZcZCJK+4DPuw==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
+      "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
       "license": "MIT",
       "dependencies": {
+        "@pinojs/redact": "^0.4.0",
         "atomic-sleep": "^1.0.0",
         "on-exit-leak-free": "^2.1.0",
         "pino-abstract-transport": "^2.0.0",
@@ -8097,7 +8094,6 @@
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
-        "slow-redact": "^0.3.0",
         "sonic-boom": "^4.0.1",
         "thread-stream": "^3.0.0"
       },
@@ -8550,23 +8546,23 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.0.tgz",
+      "integrity": "sha512-9s0pnM5tH8G4dSI3pms2GboYOs25LwOGnRMxN/Hx3TYT1K0rh6OjaWf4dI0DAQnMyaEXWoGVnSTPQasqwzTTAA==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.8"
+        "module-details-from-path": "^1.0.3"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
       "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
@@ -9108,12 +9104,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/slow-redact": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
-      "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
-      "license": "MIT"
-    },
     "node_modules/sonic-boom": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
@@ -9535,6 +9525,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9806,7 +9797,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10007,7 +9997,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/rule-901",
-  "version": "3.0.0-rc.6",
+  "version": "3.1.0-rc.1",
   "description": "Rule 901 is to calculate the number of transactions the debtor has made over a period",
   "main": "index.ts",
   "files": [
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "clean": "npx rimraf lib node_modules coverage package-lock.json",
+    "reset": "npm run clean & npm i",
     "fix": "npm run fix:prettier && npm run fix:eslint",
     "fix:eslint": "eslint --fix",
     "fix:prettier": "prettier --write \"**/*.ts\"",
@@ -32,7 +33,7 @@
     "url": "git+https://github.com/tazama-lf/rule-901.git"
   },
   "keywords": [
-    "rule-091"
+    "rule-901"
   ],
   "author": "Tazama.org",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { handleTransaction } from './rule-901';
-export { handleTransaction };
+import { handleTransaction, getRuleConfigSchema } from './rule-901';
+
+export { handleTransaction, getRuleConfigSchema };

--- a/src/rule-901.ts
+++ b/src/rule-901.ts
@@ -2,9 +2,15 @@
 
 import type { DatabaseManagerInstance, LoggerService, ManagerConfig } from '@tazama-lf/frms-coe-lib';
 import type { OutcomeResult, RuleConfig, RuleRequest, RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+import ruleConfigSchema from './schemas/ruleConfig.json';
 
 export type RuleExecutorConfig = ManagerConfig &
   Required<Pick<ManagerConfig, 'rawHistory' | 'eventHistory' | 'configuration' | 'localCacheConfig'>>;
+
+export function getRuleConfigSchema(): Record<string, unknown> {
+  return ruleConfigSchema;
+}
+
 interface CountRow {
   length: number;
 }

--- a/src/schemas/ruleConfig.json
+++ b/src/schemas/ruleConfig.json
@@ -1,0 +1,109 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "cfg": {
+            "type": "string"
+        },
+        "config": {
+            "type": "object",
+            "properties": {
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "maxQueryRange": {
+                            "type": "integer"
+                        }
+                    },
+                    "required": [
+                        "maxQueryRange"
+                    ]
+                },
+                "exitConditions": {
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "subRuleRef": {
+                                "type": "string",
+                                "enum": [
+                                    ".x00"
+                                ]
+                            },
+                            "reason": {
+                                "type": "string",
+                                "enum": [
+                                    "Incoming transaction is unsuccessful"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "subRuleRef",
+                            "reason"
+                        ],
+                        "additionalProperties": false
+                    }
+                },
+                "bands": {
+                    "type": "array",
+                    "minItems": 2,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "subRuleRef": {
+                                "type": "string"
+                            },
+                            "upperLimit": {
+                                "type": "integer"
+                            },
+                            "lowerLimit": {
+                                "type": "integer"
+                            },
+                            "reason": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "subRuleRef",
+                            "reason"
+                        ],
+                        "additionalProperties": false,
+                        "anyOf": [
+                            {
+                                "required": [
+                                    "upperLimit"
+                                ]
+                            },
+                            {
+                                "required": [
+                                    "lowerLimit"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "parameters",
+                "exitConditions",
+                "bands"
+            ]
+        },
+        "tenantId": {
+            "type": "string"
+        },
+        "desc": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "id",
+        "cfg",
+        "config",
+        "tenantId"
+    ]
+}


### PR DESCRIPTION
# SPDX-License-Identifier: Apache-2.0

## What did we change?
Added a /src/schemas/ruleConfig.json schema for rule-901's configuration
Added a `getRuleConfigSchema()` function to expose the schema for fetching by the rule-executer
Updated unit tests

## Why are we doing this?
Drive rule configuration validation via a JSON schema to obviate unnecessary and inconsistent rule config validation in rule processors, the rule-executer and the determineOutcome function.

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
