### PR TITLE
feat: add RULE_ID, ruleConfigSchema, validateConfig; remove handleTransaction config guards

### DIFF
--- a/__tests__/unit/rule.test.ts
+++ b/__tests__/unit/rule.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { type DatabaseManagerInstance, LoggerService, CreateDatabaseManager } from '@tazama-lf/frms-coe-lib';
-import { type Band, type Pacs002, type RuleConfig, type RuleRequest, type RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+import { type Pacs002, type RuleConfig, type RuleRequest, type RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 import { CreateStorageManager } from '@tazama-lf/frms-coe-lib/lib/services/dbManager';
 import { handleTransaction } from '../../src';
 import { RuleExecutorConfig } from '../../src/rule-901';
@@ -284,100 +284,6 @@ describe('Error conditions', () => {
     }
   });
 
-  test('Invalid config', async () => {
-    const mockQueryFn = jest.fn();
-
-    const mockBatchesAllFn = jest.fn().mockResolvedValue([['abc']]);
-    databaseManager._eventHistory.query = mockQueryFn.mockResolvedValue({
-      batches: {
-        all: mockBatchesAllFn,
-      },
-    });
-    jest.spyOn(databaseManager._eventHistory, 'query');
-
-    try {
-      await handleTransaction(
-        req,
-        determineOutcome,
-        ruleRes,
-        loggerService,
-        {
-          ...ruleConfig,
-          config: { ...ruleConfig.config, parameters: undefined },
-        },
-        databaseManager,
-      );
-    } catch (error) {
-      expect((error as Error).message).toBe('Invalid ruleConfig provided - parameters not provided');
-    }
-
-    try {
-      await handleTransaction(
-        req,
-        determineOutcome,
-        ruleRes,
-        loggerService,
-        {
-          ...ruleConfig,
-          config: { ...ruleConfig.config, parameters: { '1': 2 } },
-        },
-        databaseManager,
-      );
-    } catch (error) {
-      expect((error as Error).message).toBe('Invalid ruleConfig provided - maxQueryRange parameter not provided');
-    }
-
-    try {
-      await handleTransaction(
-        req,
-        determineOutcome,
-        ruleRes,
-        loggerService,
-        {
-          ...ruleConfig,
-          config: { ...ruleConfig.config, exitConditions: undefined },
-        },
-        databaseManager,
-      );
-    } catch (error) {
-      expect((error as Error).message).toBe('Invalid ruleConfig provided - exitConditions not provided');
-    }
-
-    try {
-      await handleTransaction(
-        req,
-        determineOutcome,
-        ruleRes,
-        loggerService,
-        {
-          ...ruleConfig,
-          config: { ...ruleConfig.config, bands: [] },
-        },
-        databaseManager,
-      );
-    } catch (error) {
-      expect((error as Error).message).toBe('Invalid ruleConfig provided - bands not provided or empty');
-    }
-
-    try {
-      await handleTransaction(
-        req,
-        determineOutcome,
-        ruleRes,
-        loggerService,
-        {
-          ...ruleConfig,
-          config: {
-            ...ruleConfig.config,
-            bands: undefined as unknown as Band[],
-          },
-        },
-        databaseManager,
-      );
-    } catch (error) {
-      expect((error as Error).message).toBe('Invalid ruleConfig provided - bands not provided or empty');
-    }
-  });
 });
 
 describe('Unsupported transaction type', () => {

--- a/__tests__/unit/ruleConfig.test.ts
+++ b/__tests__/unit/ruleConfig.test.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { RULE_ID, ruleConfigSchema, validateConfig } from '../../src/schemas/ruleConfig';
+import { RULE_ID } from '../../src/rule-901';
+import { ruleConfigSchema, validateConfig } from '../../src/schemas/ruleConfig';
 
 const validConfig = {
   id: '901@1.0.0',

--- a/__tests__/unit/ruleConfig.test.ts
+++ b/__tests__/unit/ruleConfig.test.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { RULE_ID, ruleConfigSchema, validateConfig } from '../../src/schemas/ruleConfig';
+
+const validConfig = {
+  id: '901@1.0.0',
+  cfg: '1.0.0',
+  tenantId: 'DEFAULT',
+  config: {
+    bands: [{ subRuleRef: '.01', reason: 'Low' }],
+    exitConditions: [{ subRuleRef: '.x00', reason: 'Unsuccessful transaction' }],
+    parameters: { maxQueryRange: 86400000 },
+  },
+};
+
+describe('RULE_ID', () => {
+  it('should equal 901', () => {
+    expect(RULE_ID).toBe('901');
+  });
+});
+
+describe('ruleConfigSchema', () => {
+  it('should accept a valid config', () => {
+    expect(() => ruleConfigSchema.parse(validConfig)).not.toThrow();
+  });
+
+  it('should reject when bands is empty', () => {
+    expect(() => ruleConfigSchema.parse({ ...validConfig, config: { ...validConfig.config, bands: [] } })).toThrow();
+  });
+
+  it('should reject when bands is absent', () => {
+    const { bands: _b, ...configNoBands } = validConfig.config;
+    expect(() => ruleConfigSchema.parse({ ...validConfig, config: configNoBands })).toThrow();
+  });
+
+  it('should reject when exitConditions is empty', () => {
+    expect(() => ruleConfigSchema.parse({ ...validConfig, config: { ...validConfig.config, exitConditions: [] } })).toThrow();
+  });
+
+  it('should reject when exitConditions is absent', () => {
+    const { exitConditions: _e, ...configNoExit } = validConfig.config;
+    expect(() => ruleConfigSchema.parse({ ...validConfig, config: configNoExit })).toThrow();
+  });
+
+  it('should reject when parameters is absent', () => {
+    const { parameters: _p, ...configNoParams } = validConfig.config;
+    expect(() => ruleConfigSchema.parse({ ...validConfig, config: configNoParams })).toThrow();
+  });
+
+  it('should reject when maxQueryRange is absent', () => {
+    expect(() =>
+      ruleConfigSchema.parse({ ...validConfig, config: { ...validConfig.config, parameters: {} } }),
+    ).toThrow();
+  });
+
+  it('should reject when maxQueryRange is not positive', () => {
+    expect(() =>
+      ruleConfigSchema.parse({ ...validConfig, config: { ...validConfig.config, parameters: { maxQueryRange: 0 } } }),
+    ).toThrow();
+    expect(() =>
+      ruleConfigSchema.parse({ ...validConfig, config: { ...validConfig.config, parameters: { maxQueryRange: -1000 } } }),
+    ).toThrow();
+  });
+
+  it('should reject when maxQueryRange is not a number', () => {
+    expect(() =>
+      ruleConfigSchema.parse({ ...validConfig, config: { ...validConfig.config, parameters: { maxQueryRange: 'daily' } } }),
+    ).toThrow();
+  });
+
+  it('should reject when top-level required fields are missing', () => {
+    const { id: _id, ...noId } = validConfig;
+    expect(() => ruleConfigSchema.parse(noId)).toThrow();
+
+    const { cfg: _cfg, ...noCfg } = validConfig;
+    expect(() => ruleConfigSchema.parse(noCfg)).toThrow();
+
+    const { tenantId: _t, ...noTenant } = validConfig;
+    expect(() => ruleConfigSchema.parse(noTenant)).toThrow();
+  });
+});
+
+describe('validateConfig', () => {
+  it('should not throw for a valid config', () => {
+    expect(() => validateConfig(validConfig as any)).not.toThrow();
+  });
+
+  it('should throw for an invalid config', () => {
+    expect(() => validateConfig({ ...validConfig, config: { ...validConfig.config, bands: [] } } as any)).toThrow();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@tazama-lf/rule-901",
-  "version": "4.0.0-rc.3",
+  "version": "4.0.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tazama-lf/rule-901",
-      "version": "4.0.0-rc.3",
+      "version": "4.0.0-rc.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tazama-lf/frms-coe-lib": "^8.0.0-rc.3"
+        "@tazama-lf/frms-coe-lib": "^8.0.0-rc.5",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",
@@ -1774,9 +1775,9 @@
       }
     },
     "node_modules/@tazama-lf/frms-coe-lib": {
-      "version": "8.0.0-rc.3",
-      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.0.0-rc.3/875069520a1710fff8de65d3788957c4302da9c0",
-      "integrity": "sha512-EATYohwL80vlTrtwGcY/JKIhSqeeu3iZYa6zDjMt4mjCNkvlF/t3NXCz+FCKhLdfkJIJyHrEbLGss0akAPdf/g==",
+      "version": "8.0.0-rc.5",
+      "resolved": "https://npm.pkg.github.com/download/@tazama-lf/frms-coe-lib/8.0.0-rc.5/ca83d3a70118dc6009a7adc3e40c2c8028b3591f",
+      "integrity": "sha512-jrRLZopffgFOaNdy0GR6/dVxIjPiTPC9Z3I01cZFMlJjuIYHaUAfhK57oQuKpz5ti4WudbTuYLT/gPmdILfCeg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.5.0",
@@ -1793,7 +1794,8 @@
         "pino": "^9.9.0",
         "pino-elasticsearch": "^8.1.0",
         "protobufjs": "^7.5.5",
-        "uuid": "^11.1.1"
+        "uuid": "^11.1.1",
+        "zod": "^4.4.3"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -10465,6 +10467,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/rule-901",
-  "version": "4.0.0-rc.3",
+  "version": "4.0.0-rc.4",
   "description": "Rule 901 is to calculate the number of transactions the debtor has made over a period",
   "main": "index.ts",
   "files": [
@@ -41,7 +41,8 @@
   },
   "homepage": "https://github.com/tazama-lf/rule-901#readme",
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "8.0.0-rc.3"
+    "@tazama-lf/frms-coe-lib": "^8.0.0-rc.5",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "homepage": "https://github.com/tazama-lf/rule-901#readme",
   "dependencies": {
-    "@tazama-lf/frms-coe-lib": "^8.0.0-rc.5",
-    "zod": "^4.4.3"
+    "@tazama-lf/frms-coe-lib": "8.0.0-rc.5",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.5.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@
 
 import { handleTransaction } from './rule-901';
 export { handleTransaction };
+export { RULE_ID, ruleConfigSchema, validateConfig } from './schemas/ruleConfig';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { handleTransaction } from './rule-901';
-export { handleTransaction };
-export { RULE_ID, ruleConfigSchema, validateConfig } from './schemas/ruleConfig';
+export { handleTransaction, RULE_ID } from './rule-901';
+export { ruleConfigSchema, validateConfig } from './schemas/ruleConfig';

--- a/src/rule-901.ts
+++ b/src/rule-901.ts
@@ -34,20 +34,13 @@ export async function handleTransaction(
 
   loggerService.trace('Start - handle transaction', context, msgId);
 
-  // Throw errors early if something we know we need is not provided - Guard Pattern
-  if (!ruleConfig.config.bands?.length) {
-    throw new Error('Invalid ruleConfig provided - bands not provided or empty');
-  }
-  if (!ruleConfig.config.exitConditions) throw new Error('Invalid ruleConfig provided - exitConditions not provided');
-  if (!ruleConfig.config.parameters) throw new Error('Invalid ruleConfig provided - parameters not provided');
-  if (!ruleConfig.config.parameters.maxQueryRange) throw new Error('Invalid ruleConfig provided - maxQueryRange parameter not provided');
   if (!req.DataCache.dbtrAcctId) throw new Error('Data Cache does not have required dbtrAcctId');
 
   // Step 1: Early exit conditions
 
   loggerService.trace('Step 1 - Early exit conditions', context, msgId);
 
-  const UnsuccessfulTransaction = ruleConfig.config.exitConditions.find((b: OutcomeResult) => b.subRuleRef === '.x00');
+  const UnsuccessfulTransaction = ruleConfig.config.exitConditions!.find((b: OutcomeResult) => b.subRuleRef === '.x00');
 
   if (req.transaction.FIToFIPmtSts.TxInfAndSts.TxSts !== 'ACCC') {
     if (UnsuccessfulTransaction === undefined) throw new Error('Unsuccessful transaction and no exit condition in ruleConfig');
@@ -65,7 +58,7 @@ export async function handleTransaction(
 
   const currentPacs002TimeFrame = req.transaction.FIToFIPmtSts.GrpHdr.CreDtTm;
   const debtorAccountId = req.DataCache.dbtrAcctId;
-  const maxQueryRange: number = ruleConfig.config.parameters.maxQueryRange as number;
+  const maxQueryRange: number = ruleConfig.config.parameters!.maxQueryRange as number;
   const tenantId = req.transaction.TenantId;
 
   const values = [debtorAccountId, currentPacs002TimeFrame, maxQueryRange, tenantId];

--- a/src/rule-901.ts
+++ b/src/rule-901.ts
@@ -4,6 +4,8 @@ import type { DatabaseManagerInstance, LoggerService, ManagerConfig } from '@taz
 import { isPacs002Transaction, isStructuredTransaction } from '@tazama-lf/frms-coe-lib';
 import type { OutcomeResult, RuleConfig, RuleRequest, RuleResult } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 
+export const RULE_ID = '901';
+
 export type RuleExecutorConfig = ManagerConfig &
   Required<Pick<ManagerConfig, 'rawHistory' | 'eventHistory' | 'configuration' | 'localCacheConfig'>>;
 interface CountRow {

--- a/src/schemas/ruleConfig.ts
+++ b/src/schemas/ruleConfig.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { baseConfigSchema, baseRuleConfigSchema, BandSchema, OutcomeResultSchema } from '@tazama-lf/frms-coe-lib';
+import type { RuleConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces';
+import { z } from 'zod';
+
+export const RULE_ID = '901';
+
+const rule901ConfigSchema = baseConfigSchema.extend({
+  bands: z.array(BandSchema).min(1),
+  exitConditions: z.array(OutcomeResultSchema).min(1),
+  parameters: z.object({
+    maxQueryRange: z.number().positive(),
+  }),
+});
+
+export const ruleConfigSchema = baseRuleConfigSchema.extend({
+  config: rule901ConfigSchema,
+});
+
+export const validateConfig = (config: RuleConfig): void => {
+  ruleConfigSchema.parse(config);
+};

--- a/src/schemas/ruleConfig.ts
+++ b/src/schemas/ruleConfig.ts
@@ -4,8 +4,6 @@ import { baseConfigSchema, baseRuleConfigSchema, BandSchema, OutcomeResultSchema
 import type { RuleConfig } from '@tazama-lf/frms-coe-lib/lib/interfaces';
 import { z } from 'zod';
 
-export const RULE_ID = '901';
-
 const rule901ConfigSchema = baseConfigSchema.extend({
   bands: z.array(BandSchema).min(1),
   exitConditions: z.array(OutcomeResultSchema).min(1),


### PR DESCRIPTION
## Summary

Adds rule identity and config validation exports to close #274, and removes the now-redundant hand-written config guards from `handleTransaction`.

### Changes

**New exports (via `src/schemas/ruleConfig.ts`):**

- `RULE_ID = '901'` - rule identity constant, consumed by rule-executer to verify the loaded module matches the expected rule
- `ruleConfigSchema` - Zod schema extending `baseRuleConfigSchema` from `@tazama-lf/frms-coe-lib` with rule-901-specific constraints:
  - `config.bands` - required, minimum 1 entry
  - `config.exitConditions` - required, minimum 1 entry
  - `config.parameters.maxQueryRange` - required positive number
- `validateConfig(config: RuleConfig): void` - throws a Zod validation error if the loaded config does not satisfy the schema; consumed by rule-executer via the `onConfigLoaded` hook (tazama-lf/frms-coe-lib#382)

**Removed from `handleTransaction`:**

The hand-written Guard Pattern block that checked `bands`, `exitConditions`, `parameters`, and `maxQueryRange` has been removed. These checks are now enforced at startup by `validateConfig` before the rule processes any transactions. The `DataCache.dbtrAcctId` guard is retained (it validates request data, not rule config).

**Dependencies updated:**

- `@tazama-lf/frms-coe-lib` bumped from `8.0.0-rc.3` to `^8.0.0-rc.5` (adds `baseRuleConfigSchema`, `baseConfigSchema`, `BandSchema`, `OutcomeResultSchema` exports)
- `zod` added as direct runtime dependency (used by `ruleConfigSchema`)

**Tests:**

- `__tests__/unit/ruleConfig.test.ts` (new) - 12 tests covering `RULE_ID`, `ruleConfigSchema` (valid config, each required field absent/invalid), and `validateConfig`
- `__tests__/unit/rule.test.ts` - removed "Invalid config" test block (those scenarios now covered by schema tests); 100% coverage maintained

**Version:** `4.0.0-rc.4` published to npm under the `rc` dist-tag.

Closes #274
