### PR TITLE
chore: bump to 4.0.0-rc.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tazama-lf/rule-901",
-  "version": "4.0.0-rc.6",
+  "version": "4.0.0-rc.7",
   "description": "Rule 901 is to calculate the number of transactions the debtor has made over a period",
   "main": "index.ts",
   "files": [


### PR DESCRIPTION
## Summary

Bumps rule-901 to `4.0.0-rc.7`.

The count-window upper-bound fix (#300, PR #301) merged into `dev` without an accompanying version bump. `4.0.0-rc.6` was already published to GitHub Packages carrying the pre-fix query, so a new RC is required so consumers can pick up the corrected build.

`@tazama-lf/rule-901@4.0.0-rc.7` (tag `rc`) has been published locally to GitHub Packages from this branch.

## Changes

- `package.json`: `4.0.0-rc.6` -> `4.0.0-rc.7`
