### PR TITLE
ci: use central release workflows (@v1)

### DIFF
--- a/.github/workflows/dev-to-main-pr.yml
+++ b/.github/workflows/dev-to-main-pr.yml
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Caller workflow: opens a release PR from the source branch to the target branch.
+#
+# Use for non-code repos or repos that do not need package.json / dependency changes.
+# For package repos, use release-train.yml instead.
+#
+# Usage:
+#   Trigger manually from the source branch (dev).
+#   Optionally pass release_version for the PR title.
+#
+# This file is managed centrally - do not edit manually.
+# To change behaviour, update the reusable workflow in tazama-lf/workflows.
+
+name: Dev to Main PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Optional release version. Leave blank to use repo/org variable RELEASE_VERSION or DEFAULT_RELEASE_VERSION."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dev-to-main-pr:
+    uses: tazama-lf/workflows/.github/workflows/dev-to-main-pr.yml@v1
+    with:
+      source_branch: ${{ vars.SOURCE_BRANCH || 'dev' }}
+      target_branch: ${{ vars.TARGET_BRANCH || 'main' }}
+      release_version: ${{ inputs.release_version || vars.RELEASE_VERSION || vars.DEFAULT_RELEASE_VERSION || '' }}
+      reviewer: ${{ vars.RELEASE_REVIEWER || '' }}
+    secrets: inherit

--- a/.github/workflows/package-rule-rc.yml
+++ b/.github/workflows/package-rule-rc.yml
@@ -1,16 +1,34 @@
 # SPDX-License-Identifier: Apache-2.0
+
+# Caller workflow: builds and pushes the RC Docker image for this rule processor.
+#
+# Triggers:
+#   - Automatically on push to the source branch (dev) for rc package versions.
+#   - Manually via workflow_dispatch.
+#
 # This file is managed centrally - do not edit manually.
 # To change build behaviour, update the reusable workflow in tazama-lf/workflows.
+
+name: Package RC rule image
+
 on:
   push:
-    branches: [dev]
-  repository_dispatch:
-    types: [rule-executer-update]
+    branches:
+      - dev
   workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
 jobs:
-  build:
-    uses: tazama-lf/workflows/.github/workflows/package-rule-rc.yml@dev
+  package-rule-rc:
+    uses: tazama-lf/workflows/.github/workflows/package-rule-rc.yml@v1
     with:
-      rule_number: "901"
-      rule_org: "tazama-lf"
+      rule_number: ${{ vars.RULE_NUMBER || '901' }}
+      rule_org: ${{ vars.RULE_ORG || 'frmscoe' }}
+      node_version: ${{ vars.NODE_VERSION || '22' }}
+      rule_executer_repo: ${{ vars.RULE_EXECUTER_REPO || 'tazama-lf/rule-executer' }}
+      rule_executer_branch: ${{ vars.RULE_EXECUTER_BRANCH || 'dev' }}
+      docker_image_namespace: ${{ vars.DOCKER_IMAGE_NAMESPACE || 'tazamaorg' }}
     secrets: inherit

--- a/.github/workflows/package-rule.yml
+++ b/.github/workflows/package-rule.yml
@@ -1,14 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
+
+# Caller workflow: builds and pushes the stable Docker image for this rule processor.
+#
+# Triggers:
+#   - Automatically on push to the target branch (main) after stable release merge.
+#   - Manually via workflow_dispatch.
+#
+# Produces a versioned Docker tag and the :latest pointer for this rule.
+#
 # This file is managed centrally - do not edit manually.
 # To change build behaviour, update the reusable workflow in tazama-lf/workflows.
+
+name: Package stable rule image
+
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: read
+
 jobs:
-  build:
-    uses: tazama-lf/workflows/.github/workflows/package-rule.yml@main
+  package-rule:
+    uses: tazama-lf/workflows/.github/workflows/package-rule.yml@v1
     with:
-      rule_number: "901"
-      rule_org: "tazama-lf"
+      rule_number: ${{ vars.RULE_NUMBER || '901' }}
+      rule_org: ${{ vars.RULE_ORG || 'frmscoe' }}
+      node_version: ${{ vars.NODE_VERSION || '22' }}
+      rule_executer_repo: ${{ vars.RULE_EXECUTER_REPO || 'tazama-lf/rule-executer' }}
+      rule_executer_branch: ${{ vars.RULE_EXECUTER_BRANCH || 'main' }}
+      docker_image_namespace: ${{ vars.DOCKER_IMAGE_NAMESPACE || 'tazamaorg' }}
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,100 +1,42 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# This workflow publishes an npm package to the GitHub Package Registry (@tazama-lf scope).
+# Caller workflow: publishes this repo's npm package to GitHub Packages.
 #
-# Versioning policy:
-#   The version in package.json is the only signal used to determine the dist-tag:
-#     - Prerelease (X.Y.Z-rc.N)  → published under the 'rc' dist-tag  (triggered manually from dev)
-#     - Stable (X.Y.Z)           → published under 'latest' dist-tag   (triggered automatically on merge to main)
+# Versioning policy (handled by the central publish.yml):
+#   - Prerelease versions on the source branch (e.g. 4.0.0-rc.4) publish with dist-tag "rc".
+#   - Stable versions on the target branch (e.g. 4.0.0) publish with dist-tag "latest".
 #
-#   Developers set the version in package.json manually. The version-check.yml workflow
-#   enforces that no prerelease version can merge to main.
+# Triggers:
+#   - Automatically on push to the target branch when package.json or package-lock.json changes
+#     (typically after the release PR is merged).
+#   - Manually via workflow_dispatch from the target branch.
 #
-# Resolves: https://github.com/tazama-lf/workflows/issues/27
-#
-# Please do not attempt to edit this flow without the direct consent from the DevOps team.
-# This file is managed centrally.
+# This file is managed centrally - do not edit manually.
+# To change publish behaviour, update the reusable workflow in tazama-lf/workflows.
 
-name: Publish npm package to GitHub Packages
+name: Publish npm package
 
 on:
   push:
     branches:
       - main
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
   workflow_dispatch:
 
+permissions:
+  packages: write
+  contents: read
+
 jobs:
-  build-and-publish:
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          token: ${{ secrets.GH_TOKEN_LIB }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
-        with:
-          node-version: '22'
-          registry-url: 'https://npm.pkg.github.com/'
-          scope: '@tazama-lf'
-
-      - name: Set up npm authentication
-        run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_TOKEN_LIB }}" >> ~/.npmrc
-
-      - name: Install dependencies
-        run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
-
-      - name: Build
-        run: npm run build
-
-      - name: Publish package
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          if [[ "$VERSION" == *-* ]]; then
-            # Prerelease version (e.g. 1.2.3-rc.1): publish under the 'rc' dist-tag
-            # so it does not become the default 'latest' install target.
-            npm publish --tag rc
-          else
-            npm publish
-          fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
-
-      # Send Slack notification - requires SLACK_WEBHOOK_URL org/repo secret
-      - name: Send Slack notification
-        continue-on-error: true
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": "New npm package published :white_check_mark:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Repository:*\nhttps://github.com/${{ github.repository }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Triggered by:*\n${{ github.actor }}"
-                  }
-                ]
-              }
-            ]
-          }' "$SLACK_WEBHOOK_URL"
+  publish:
+    uses: tazama-lf/workflows/.github/workflows/publish.yml@v1
+    with:
+      node_version: ${{ vars.NODE_VERSION || '22' }}
+      package_scope: ${{ vars.PACKAGE_SCOPE || '@frmscoe' }}
+      run_build: ${{ vars.RUN_BUILD != 'false' }}
+      build_command: ${{ vars.BUILD_COMMAND || 'npm run build' }}
+      skip_if_already_published: ${{ vars.SKIP_IF_ALREADY_PUBLISHED != 'false' }}
+      publish_branch: ${{ vars.TARGET_BRANCH || 'main' }}
+    secrets: inherit

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -1,262 +1,54 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Prepares and opens a release PR from dev → main for a library package.
+# Caller workflow: prepares and opens a release PR from the source branch to the target branch.
 #
-# Usage: trigger manually from the dev branch with the target stable version.
-#   - The version input MUST be a clean semver (e.g. "4.0.0") with no prerelease suffix.
-#   - The workflow resolves all internal rc dependencies to their stable equivalents,
-#     regenerates package-lock.json, commits via the GitHub API (producing a Verified
-#     commit that satisfies branch protection), and opens a PR → main for review.
-#   - After the PR is reviewed and merged, publish.yml fires automatically on push: main
-#     and publishes the package under the 'latest' dist-tag.
+# Use for package repos, libraries, services, and rule repos that have package.json.
 #
-# Dependency resolution rules:
-#   Pinned rc    (e.g. "7.0.2-rc.2")       → replace with npm dist-tags.latest; fail if not stable
-#   Range with rc (e.g. "^4.0.0-rc.4")     → strip prerelease from base → "^4.0.0"; fail if latest < base
-#   Pinned stable / range stable            → leave unchanged
+# Usage:
+#   Trigger manually from the source branch (dev).
+#   Leave version blank: orchestrator passes REL_VERSION; central workflow uses that for the
+#   platform release (release/v4.0.0) and falls back to RELEASE_VERSION, then package.json.
 #
-# Please do not attempt to edit this flow without the direct consent from the DevOps team.
-# This file is managed centrally.
+# Version policies (PACKAGE_VERSION_POLICY repo variable):
+#   aligned     - package.json is set to the platform release version (services, rules, apps).
+#   independent - package.json keeps its own semver (e.g. 8.2.0); platform release is still v4.0.0.
+#
+# What the central workflow does:
+#   1. Platform version: workflow input → RELEASE_VERSION → package.json fallback.
+#   2. npm version: aligned → platform version; independent → package.json own semver.
+#   3. Opens release PR branch (release/vX.Y.Z) and resolves internal rc deps to stable.
+#   4. Regenerates package-lock.json when present.
+#
+# After the release PR is merged to the target branch, publish.yml runs automatically.
+#
+# This file is managed centrally - do not edit manually.
+# To change release-train behaviour, update the reusable workflow in tazama-lf/workflows.
 
 name: Release train
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Platform release version (e.g. 4.0.0). Leave blank to use RELEASE_VERSION, then package.json."
+        required: false
+        default: ""
 
 permissions:
   contents: write
   pull-requests: write
 
-# checkov:skip=CKV_GHA_7:Release train is operator-controlled; version input is validated and
-# only determines the release branch name / package.json version - not the build artifact source.
-on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Target stable version (e.g. 4.0.0) - must not contain a prerelease suffix'
-        required: true
-        type: string
-
 jobs:
-  prepare-release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    env:
-      VERSION_INPUT: ${{ inputs.version }}
-
-    steps:
-      - name: Validate version input
-        run: |
-          VERSION="$VERSION_INPUT"
-          if [[ "$VERSION" == *-* ]]; then
-            echo "❌ Version input '$VERSION' contains a prerelease suffix."
-            echo "   Provide a clean semver (e.g. 4.0.0), not a prerelease."
-            exit 1
-          fi
-          # Basic semver format check: X.Y.Z
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "❌ Version input '$VERSION' is not a valid semver (expected X.Y.Z)."
-            exit 1
-          fi
-          echo "✅ Version input '$VERSION' is valid."
-
-      - name: Checkout dev branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: dev
-          token: ${{ secrets.GH_TOKEN_LIB }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
-        with:
-          node-version: '22'
-          registry-url: 'https://npm.pkg.github.com/'
-          scope: '@tazama-lf'
-
-      - name: Add @frmscoe registry scope
-        run: echo "@frmscoe:registry=https://npm.pkg.github.com/" >> ~/.npmrc
-
-      - name: Resolve internal rc dependencies to stable
-        id: resolve_deps
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
-        run: |
-          CHANGED=0
-          PKG=$(cat package.json)
-
-          # Process both dependencies and devDependencies
-          for DEP_FIELD in dependencies devDependencies peerDependencies; do
-            # Get all @tazama-lf and @frmscoe keys in this field
-            KEYS=$(echo "$PKG" | jq -r ".${DEP_FIELD} // {} | keys[]" | grep -E '^@(tazama-lf|frmscoe)/' || true)
-            for KEY in $KEYS; do
-              CURRENT=$(echo "$PKG" | jq -r ".${DEP_FIELD}[\"${KEY}\"]")
-              echo "Checking $KEY = $CURRENT"
-
-              # Detect pinned rc: X.Y.Z-rc.N (no leading ^ or ~)
-              if [[ "$CURRENT" =~ ^[0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z] ]]; then
-                LATEST=$(npm view "${KEY}" dist-tags.latest 2>/dev/null || true)
-                if [ -z "$LATEST" ]; then
-                  echo "❌ Cannot resolve stable version for ${KEY} (pinned rc: ${CURRENT})"
-                  exit 1
-                fi
-                if [[ "$LATEST" == *-* ]]; then
-                  echo "❌ ${KEY}@latest is '${LATEST}' (still a prerelease). Publish stable first."
-                  exit 1
-                fi
-                echo "  → $KEY: $CURRENT → $LATEST"
-                PKG=$(echo "$PKG" | jq ".${DEP_FIELD}[\"${KEY}\"] = \"${LATEST}\"")
-                CHANGED=1
-
-              # Detect range with rc prefix: ^X.Y.Z-rc.N or ~X.Y.Z-rc.N
-              elif [[ "$CURRENT" =~ ^[\^~][0-9]+\.[0-9]+\.[0-9]+-[a-zA-Z] ]]; then
-                RANGE_CHAR="${CURRENT:0:1}"
-                BASE="${CURRENT:1}"
-                STABLE_BASE="${BASE%%-*}"  # strip -rc.N from base
-                LATEST=$(npm view "${KEY}" dist-tags.latest 2>/dev/null || true)
-                if [ -z "$LATEST" ]; then
-                  echo "❌ Cannot resolve stable version for ${KEY} (range with rc: ${CURRENT})"
-                  exit 1
-                fi
-                if [[ "$LATEST" == *-* ]]; then
-                  echo "❌ ${KEY}@latest is '${LATEST}' (still a prerelease). Publish stable first."
-                  exit 1
-                fi
-                NEW_RANGE="${RANGE_CHAR}${STABLE_BASE}"
-                echo "  → $KEY: $CURRENT → $NEW_RANGE"
-                PKG=$(echo "$PKG" | jq ".${DEP_FIELD}[\"${KEY}\"] = \"${NEW_RANGE}\"")
-                CHANGED=1
-
-              else
-                echo "  ✅ $KEY: $CURRENT (no change needed)"
-              fi
-            done
-          done
-
-          # Write resolved package.json
-          echo "$PKG" | jq '.' > package.json
-
-          echo "changed=$CHANGED" >> "$GITHUB_OUTPUT"
-          echo "Dependency resolution complete (changed=$CHANGED)"
-
-      - name: Update version in package.json
-        run: |
-          VERSION="$VERSION_INPUT"
-          jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp
-          mv package.json.tmp package.json
-          echo "Version set to $VERSION"
-
-      - name: Regenerate package-lock.json
-        run: npm install --package-lock-only
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
-
-      - name: Commit and push to release branch via GitHub API
-        id: push_branch
-        env:
-          GH_API_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
-        run: |
-          VERSION="$VERSION_INPUT"
-          BRANCH="release/v${VERSION}"
-          REPO="${{ github.repository }}"
-          API="https://api.github.com/repos/${REPO}"
-
-          # Get current dev branch SHA to base the new branch on
-          DEV_SHA=$(curl -s -H "Authorization: Bearer $GH_API_TOKEN" \
-            "${API}/git/ref/heads/dev" | jq -r '.object.sha')
-          if [ -z "$DEV_SHA" ] || [ "$DEV_SHA" = "null" ]; then
-            echo "❌ Failed to get dev branch SHA - check API permissions"
-            exit 1
-          fi
-          echo "Dev SHA: $DEV_SHA"
-
-          # Create the release branch; if it already exists force-reset to current dev HEAD
-          # so that reruns always build from the latest dev state (not a stale branch tip)
-          CREATE_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X POST -H "Authorization: Bearer $GH_API_TOKEN" \
-            -H "Content-Type: application/json" \
-            "${API}/git/refs" \
-            -d "{\"ref\":\"refs/heads/${BRANCH}\",\"sha\":\"${DEV_SHA}\"}")
-          if [ "$CREATE_HTTP" = "201" ]; then
-            echo "Branch $BRANCH created at $DEV_SHA"
-          else
-            echo "Branch $BRANCH already exists - force-resetting to dev HEAD ($DEV_SHA)"
-            curl -s -X PATCH -H "Authorization: Bearer $GH_API_TOKEN" \
-              -H "Content-Type: application/json" \
-              "${API}/git/refs/heads/${BRANCH}" \
-              -d "{\"sha\":\"${DEV_SHA}\",\"force\":true}" | jq -r '.ref // .message'
-          fi
-
-          # Branch is now pinned to DEV_SHA in both cases
-          BRANCH_SHA="$DEV_SHA"
-          TREE_SHA=$(curl -s -H "Authorization: Bearer $GH_API_TOKEN" \
-            "${API}/git/commits/${BRANCH_SHA}" | jq -r '.tree.sha')
-          if [ -z "$TREE_SHA" ] || [ "$TREE_SHA" = "null" ]; then
-            echo "❌ Failed to get tree SHA for commit $BRANCH_SHA"
-            exit 1
-          fi
-
-          # Build new tree with updated files
-          NEW_TREE=$(curl -s -X POST -H "Authorization: Bearer $GH_API_TOKEN" \
-            -H "Content-Type: application/json" \
-            "${API}/git/trees" \
-            -d "{
-              \"base_tree\": \"${TREE_SHA}\",
-              \"tree\": [
-                {\"path\":\"package.json\",\"mode\":\"100644\",\"type\":\"blob\",\"content\":$(jq -Rs '.' package.json)},
-                {\"path\":\"package-lock.json\",\"mode\":\"100644\",\"type\":\"blob\",\"content\":$(jq -Rs '.' package-lock.json)}
-              ]
-            }" | jq -r '.sha')
-          if [ -z "$NEW_TREE" ] || [ "$NEW_TREE" = "null" ]; then
-            echo "❌ Failed to create new tree via GitHub API"
-            exit 1
-          fi
-          echo "New tree SHA: $NEW_TREE"
-
-          # Create commit (GitHub API produces Verified commits)
-          NEW_COMMIT=$(curl -s -X POST -H "Authorization: Bearer $GH_API_TOKEN" \
-            -H "Content-Type: application/json" \
-            "${API}/git/commits" \
-            -d "{
-              \"message\": \"chore: prepare release v${VERSION}\n\n- Set version to ${VERSION}\n- Resolve internal rc dependencies to stable\n- Regenerate package-lock.json\",
-              \"tree\": \"${NEW_TREE}\",
-              \"parents\": [\"${BRANCH_SHA}\"]
-            }" | jq -r '.sha')
-          if [ -z "$NEW_COMMIT" ] || [ "$NEW_COMMIT" = "null" ]; then
-            echo "❌ Failed to create commit via GitHub API"
-            exit 1
-          fi
-          echo "New commit SHA: $NEW_COMMIT"
-
-          # Update the branch ref to the new commit
-          curl -s -X PATCH -H "Authorization: Bearer $GH_API_TOKEN" \
-            -H "Content-Type: application/json" \
-            "${API}/git/refs/heads/${BRANCH}" \
-            -d "{\"sha\":\"${NEW_COMMIT}\"}" | jq -r '.ref // .message'
-
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-          echo "Branch $BRANCH updated to commit $NEW_COMMIT"
-
-      - name: Open PR to main
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN_LIB }}
-          GH_USERNAME: ${{ secrets.GH_USERNAME }}
-        run: |
-          VERSION="$VERSION_INPUT"
-          BRANCH="${{ steps.push_branch.outputs.branch }}"
-
-          # Write PR body to temp file using printf to avoid heredoc/YAML conflicts
-          printf "## Release v%s\n\nThis PR was prepared automatically by release-train.yml.\n\n**Changes:**\n- Version bumped to %s\n- Internal rc dependencies resolved to stable\n- package-lock.json regenerated\n\n**After merging:**\n- publish.yml will fire on push to main and publish %s under the latest dist-tag.\n\nPlease review the dependency changes and version bump before approving.\n" \
-            "$VERSION" "$VERSION" "$VERSION" > /tmp/pr-body.md
-
-          if ! gh pr create \
-            --title "release: v${VERSION}" \
-            --body-file /tmp/pr-body.md \
-            --base main \
-            --head "$BRANCH" \
-            --reviewer "$GH_USERNAME"; then
-            EXISTING=$(gh pr list --head "$BRANCH" --base main --json number --jq '.[0].number // empty')
-            if [ -n "$EXISTING" ]; then
-              echo "PR #${EXISTING} already exists for $BRANCH - skipping."
-            else
-              echo "❌ gh pr create failed and no existing PR was found."
-              exit 1
-            fi
-          fi
+  release-train:
+    uses: tazama-lf/workflows/.github/workflows/release-train.yml@v1
+    with:
+      version: ${{ inputs.version || '' }}
+      version_policy: ${{ vars.PACKAGE_VERSION_POLICY || 'aligned' }}
+      source_branch: ${{ vars.SOURCE_BRANCH || 'dev' }}
+      target_branch: ${{ vars.TARGET_BRANCH || 'main' }}
+      package_scope: ${{ vars.PACKAGE_SCOPE || '@frmscoe' }}
+      node_version: ${{ vars.NODE_VERSION || '22' }}
+      internal_scopes_regex: ${{ vars.INTERNAL_SCOPES_REGEX || '^@(tazama-lf|frmscoe)/' }}
+      version_mismatch_behavior: ${{ vars.VERSION_MISMATCH_BEHAVIOR || 'fail' }}
+      reviewer: ${{ vars.RELEASE_REVIEWER || '' }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,249 +1,55 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Please do not attempt to edit this flow without the direct consent from the DevOps team. This file is managed centrally.
+# Caller workflow: creates a GitHub release and tag for this repo.
+#
+# Triggers:
+#   - Automatically on push to the target branch (main) when package.json changes,
+#     i.e. right after the release-train PR is merged. This completes the release (tag + GitHub
+#     release) alongside publish.yml (npm) and any package image builds.
+#   - Manually via workflow_dispatch from the target branch.
+#
+# What the central workflow does:
+#   1. Creates a platform GitHub release/tag from RELEASE_VERSION (e.g. v4.0.0).
+#   2. Records the npm package.json version in release notes when present.
+#   3. Generates a changelog from commits since the previous tag.
+#   (The central workflow is idempotent: it skips if the tag/release already exists.)
+#
+# This file is managed centrally - do not edit manually.
+# To change release behaviour, update the reusable workflow in tazama-lf/workflows.
 
-name: Release Workflow
+name: Release
 
 on:
-  repository_dispatch:
-    types: [release]
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+    inputs:
+      tag_version:
+        description: "Platform GitHub release tag version. Leave blank to use RELEASE_VERSION."
+        required: false
+        default: ""
+      default_version:
+        description: "Fallback platform version for repos without package.json."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  actions: read
 
 jobs:
   release:
-    if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'
-    runs-on: ubuntu-latest
-    steps:
-      # Checkout the main branch with all history
-      - name: Checkout Repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2 (upgraded from v2)
-        with:
-          ref: main
-          fetch-depth: 0 # Fetch all tags
-
-      # Determine the release type (major, minor, patch) based on commit messages  
-      - name: Determine Release Type
-        id: determine_release
-        run: |
-          PREV_VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || echo "")
-          echo "Previous Version: ${PREV_VERSION:-none (first release)}"
-          GIT_LOG_RANGE="${PREV_VERSION:+${PREV_VERSION}..}HEAD"
-
-          COMMIT_MESSAGES=$(git log $GIT_LOG_RANGE --format=%B)
-          echo "Commit Messages: $COMMIT_MESSAGES"
-          
-          # Determine release type based on commit messages and labels
-          RELEASE_TYPE="patch"  # Default to patch
-          
-          if echo "$COMMIT_MESSAGES" | grep -q -e "BREAKING CHANGE:"; then
-            RELEASE_TYPE="major"
-          elif echo "$COMMIT_MESSAGES" | grep -q -e "feat!:"; then
-            RELEASE_TYPE="major"
-          elif echo "$COMMIT_MESSAGES" | grep -q -e "feat:"; then
-            RELEASE_TYPE="minor"
-          elif echo "$COMMIT_MESSAGES" | grep -q -e "fix:" -e "enhancement:" -e "docs:" -e "refactor:" -e "chore:" -e "build:" -e "ci:" -e "perf:" -e "style:" -e "test:" -e "chore(deps):" -e "chore(deps-dev):"; then
-            RELEASE_TYPE="patch"
-          fi
-          
-          echo "Release Type: $RELEASE_TYPE"
-          echo "release_type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
-        
-      # Bump the version based on the determined release type
-      - name: Bump Version
-        id: bump_version
-        run: |
-          PREV_VERSION=$(git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0")
-          echo "Previous Version: $PREV_VERSION"
-          
-          RELEASE_TYPE=${{ steps.determine_release.outputs.release_type }}
-          echo "Release Type: $RELEASE_TYPE"
-          
-          # Strip the 'v' from the version if it exists
-          PREV_VERSION=${PREV_VERSION#v}
-          
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$PREV_VERSION"
-          
-          if [[ $RELEASE_TYPE == "major" ]]; then
-            MAJOR=$((MAJOR + 1))
-            MINOR=0
-            PATCH=0
-          elif [[ $RELEASE_TYPE == "minor" ]]; then
-            MINOR=$((MINOR + 1))
-            PATCH=0
-          else
-            PATCH=$((PATCH + 1))
-          fi
-          
-          NEW_VERSION="v$MAJOR.$MINOR.$PATCH"
-          echo "New Version: $NEW_VERSION"
-          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-
-      # Get the milestone details
-      - name: Get Milestone Details
-        id: get_milestone
-        env:
-          MILESTONE_NUMBER: ${{ github.event.client_payload.milestone_number }}
-        run: |
-          if [[ -z "$MILESTONE_NUMBER" ]]; then
-            echo "::error::MILESTONE_NUMBER is not set in client_payload"
-            exit 1
-          fi
-          MILESTONE_RESPONSE=$(curl --fail -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/milestones/${MILESTONE_NUMBER}")
-          MILESTONE_TITLE=$(echo "$MILESTONE_RESPONSE" | jq -r '.title')
-          MILESTONE_DESCRIPTION=$(echo "$MILESTONE_RESPONSE" | jq -r '.description')
-          MILESTONE_DATE=$(echo "$MILESTONE_RESPONSE" | jq -r '.due_on')
-          echo "milestone_title=$MILESTONE_TITLE" >> "$GITHUB_OUTPUT"
-          {
-            echo 'milestone_description<<EOF'
-            echo "$MILESTONE_DESCRIPTION"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
-          echo "milestone_date=$MILESTONE_DATE" >> "$GITHUB_OUTPUT"
-
-      # Generate the changelog based on commit messages and labels
-      - name: Generate Changelog
-        id: generate_changelog
-        run: |
-          # Generate Changelog Script
-          # Constants
-          CHANGELOG_FILE="/home/runner/work/changelog.txt"
-          LABEL_BUG="fix:"
-          LABEL_FEATURE="feat:"
-          LABEL_ENHANCEMENT="enhancement:"
-          LABEL_DOCS="docs:"
-          LABEL_REFACTOR="refactor:"
-          LABEL_CHORE="chore:"
-          LABEL_BUILD="build:"
-          LABEL_CI="ci:"
-          LABEL_PERFORMANCE="perf:"
-          LABEL_STYLE="style:"
-          LABEL_TEST="test:"
-          LABEL_BREAKING_CHANGE="BREAKING CHANGE:"
-          LABEL_FEAT_BREAKING="feat!:"
-          LABEL_DEPS="chore(deps):"
-          LABEL_DEPS_DEV="chore(deps-dev):"
-          # Get the last release tag
-          LAST_RELEASE_TAG=$(git describe --abbrev=0 --tags 2>/dev/null || echo "")
-          GIT_LOG_RANGE="${LAST_RELEASE_TAG:+${LAST_RELEASE_TAG}..}HEAD"
-          echo "Last Release Tag: ${LAST_RELEASE_TAG:-none (first release)}"
-          # Get the milestone details from the output of the previous step
-          MILESTONE_TITLE="${{ steps.get_milestone.outputs.milestone_title }}"
-          MILESTONE_DESCRIPTION="${{ steps.get_milestone.outputs.milestone_description }}"
-          MILESTONE_DATE="${{ steps.get_milestone.outputs.milestone_date }}"
-          # Append the milestone details to the changelog file
-          echo "## Milestone: $MILESTONE_TITLE" >> "$CHANGELOG_FILE"
-          echo "Date: $MILESTONE_DATE" >> "$CHANGELOG_FILE"
-          echo "Description: $MILESTONE_DESCRIPTION" >> "$CHANGELOG_FILE"
-          echo "" >> "$CHANGELOG_FILE"
-          # Function to append section to the changelog file
-          append_section() {
-            local section_title="$1"
-            local section_label="$2"
-            local section_icon="$3"
-            # Get the commit messages with the specified label between the last release and the current release
-            local commit_messages=$(git log --pretty=format:"- %s (Linked Issues: %C(yellow)%H%Creset)" $GIT_LOG_RANGE --grep="$section_label" --no-merges --decorate --decorate-refs=refs/issues)
-            # If there are commit messages, append the section to the changelog file
-            if [ -n "$commit_messages" ]; then
-              # Remove duplicate commit messages
-              local unique_commit_messages=$(echo "$commit_messages" | awk '!seen[$0]++')
-              echo "### $section_icon $section_title" >> "$CHANGELOG_FILE"
-              echo "" >> "$CHANGELOG_FILE"
-              echo "$unique_commit_messages" >> "$CHANGELOG_FILE"
-              echo "" >> "$CHANGELOG_FILE"
-            fi
-          }
-          # Append sections to the changelog file based on labels
-          append_section "Bug Fixes" "$LABEL_BUG" "🐞"
-          append_section "New Features" "$LABEL_FEATURE" "⭐️"
-          append_section "Enhancements" "$LABEL_ENHANCEMENT" "✨"
-          append_section "Documentation" "$LABEL_DOCS" "📚"
-          append_section "Refactorings" "$LABEL_REFACTOR" "🔨"
-          append_section "Chores" "$LABEL_CHORE" "⚙️"
-          append_section "Build" "$LABEL_BUILD" "🏗️"
-          append_section "CI" "$LABEL_CI" "⚙️"
-          append_section "Performance" "$LABEL_PERFORMANCE" "🚀"
-          append_section "Style" "$LABEL_STYLE" "💅"
-          append_section "Tests" "$LABEL_TEST" "🧪"
-          append_section "Breaking Changes" "$LABEL_BREAKING_CHANGE" "💥"
-          append_section "Feature Breaking Changes" "$LABEL_FEAT_BREAKING" "💥"
-          append_section "Dependencies" "$LABEL_DEPS" "📦"
-          append_section "Dev Dependencies" "$LABEL_DEPS_DEV" "🔧"
-          
-          # Function to append non-labeled commits to the changelog file
-          append_non_labeled_commits() {
-            # Get the commit messages that do not match any conventional commit labels between the last release and the current release
-            local non_labeled_commit_messages=$(git log --pretty=format:"- %s (Linked Issues: %C(yellow)%H%Creset)" $GIT_LOG_RANGE --invert-grep --grep="^fix:\|^feat:\|^enhancement:\|^docs:\|^refactor:\|^chore:\|^build:\|^ci:\|^perf:\|^style:\|^test:\|^BREAKING CHANGE:\|^feat!:\|^chore(deps):\|^chore(deps-dev):")
-            # If there are non-labeled commit messages, append the section to the changelog file
-            if [ -n "$non_labeled_commit_messages" ]; then
-              # Remove duplicate commit messages
-              local unique_commit_messages=$(echo "$non_labeled_commit_messages" | awk '!seen[$0]++')
-              echo "### 📝 Other Changes" >> "$CHANGELOG_FILE"
-              echo "" >> "$CHANGELOG_FILE"
-              echo "$unique_commit_messages" >> "$CHANGELOG_FILE"
-              echo "" >> "$CHANGELOG_FILE"
-            fi
-          }
-          # Append non-labeled commits to the changelog file
-          append_non_labeled_commits
-
-          echo "changelog_file=$CHANGELOG_FILE" >> "$GITHUB_OUTPUT"
-
-      # Read changelog contents into a variable
-      - name: Read Changelog Contents
-        id: read_changelog
-        run: |
-          {
-            echo 'changelog_contents<<EOF'
-            cat /home/runner/work/changelog.txt
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
-      
-      # Display changelog
-      - name: Display Changelog
-        run: cat /home/runner/work/changelog.txt
-      
-      # Attach changelog as an artifact
-      - name: Attach Changelog to Release
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
-        with:
-          name: Changelog
-          path: /home/runner/work/changelog.txt
-      
-      # Create release while including the changelog
-      - name: Create Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${{ steps.bump_version.outputs.new_version }}" \
-            --title "${{ steps.bump_version.outputs.new_version }}" \
-            --notes-file /home/runner/work/changelog.txt
-
-      - name: Send Slack Notification
-        continue-on-error: true
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        run: |
-          curl --fail -sS -X POST -H 'Content-type: application/json' --data '{
-            "blocks": [
-              {
-                "type": "header",
-                "text": {
-                  "type": "plain_text",
-                  "text": "New Release Alert :tazama:",
-                  "emoji": true
-                }
-              },
-              {
-                "type": "section",
-                "fields": [
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Github Repository:*\nhttps://github.com/${{ github.repository }}"
-                  },
-                  {
-                    "type": "mrkdwn",
-                    "text": "*Release:*\n<https://github.com/${{ github.repository }}/releases/tag/${{ steps.bump_version.outputs.new_version }}|Release notes>"
-                  }
-                ]
-              }
-            ]
-          }' "$SLACK_WEBHOOK_URL"
+    uses: tazama-lf/workflows/.github/workflows/release.yml@v1
+    with:
+      tag_version: ${{ inputs.tag_version || vars.RELEASE_VERSION || vars.DEFAULT_RELEASE_VERSION || '' }}
+      default_version: ${{ inputs.default_version || vars.DEFAULT_RELEASE_VERSION || vars.RELEASE_VERSION || '0.0.0' }}
+      expected_version: ${{ inputs.tag_version || vars.RELEASE_VERSION || vars.DEFAULT_RELEASE_VERSION || '' }}
+      version_policy: ${{ vars.PACKAGE_VERSION_POLICY || 'aligned' }}
+      version_mismatch_behavior: ${{ vars.VERSION_MISMATCH_BEHAVIOR || 'fail' }}
+      release_branch: ${{ vars.TARGET_BRANCH || 'main' }}
+      milestone_number: ${{ vars.RELEASE_MILESTONE_NUMBER || '' }}
+    secrets: inherit


### PR DESCRIPTION
This PR replaces/updates local release workflows with small caller workflows that use tazama-lf/workflows@v1.